### PR TITLE
City and Road events

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2859,17 +2859,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 56,
     text:
-      'At first the man looks dead, with numerous open wounds and lying in a pool of blood in the dirt+ r then he coughs and whispers something unintelligible. The man looks pretty bad off likely attacked by some wild animal, but its possible he could be saved.',
+      'At first the man looks dead, with numerous open wounds and lying in a pool of blood in the dirt/\n\nBut then he coughs and whispers something unintelligible. The man looks pretty bad off, likely attacked by some wild animal, but it\'s possible he could be saved.',
     optionA: {
       choice: 'Help the wounded man as best you can.',
       outcome:
-        "■' ' ■ \"WKm*. ■' 4*.d .mm i ^ The nun's wounds actually look worse than they really are, and your time with the Sawbones has given you some experience in what to do. You hind the wounds to stop the bleeding and then give him something to eat. He lost a lot of blood, but after some nursing, he's able to stand and make his way back to Gloomhaven, thanking you profusely in the process.\n\nGain 1 reputation.",
+        "The man's wounds actually look worse than they really are, and your time with the Sawbones has given you some experience in what to do. You bind the wounds to stop the bleeding and then give him something to eat. He lost a lot of blood, but after some nursing, he's able to stand and make his way back to Gloomhaven, thanking you profusely in the process.\n\nGain 1 reputation.",
       imageUrl: '/assets/cards/events/base/road/re-56-b-a.png',
     },
     optionB: {
       choice: 'Let the man die and take his belongings.',
       outcome:
-        "You riffle through the man 's pockets as he speaks his last words. They're too soft to make out, but the tone is one of anger and disappointment. You make off with a decent amount of money and leave the corpse to rot.\n\nGain 3 gold each.",
+        "You riffle through the man's pockets as he speaks his last words. They're too soft to make out, but the tone is one of anger and disappointment. You make off with a decent amount of money and leave the corpse to rot.\n\nGain 3 gold each.",
       imageUrl: '/assets/cards/events/base/road/re-56-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-56-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1269,17 +1269,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 61,
     text:
-      'The day proves uneventful until you head back to your room in the evening to find a small package waiting at your doorstep. Resting on it is another note from the Tinkerer: He thanks you profusely for sending along the mechanical spider, saying it was a great help in his work. He doesn t need it any longer, however and decided to send it back. He explains that he made a few improvements to it as well while it was in his possession, and that it should help you significantly in your adventures.',
+      'The day proves uneventful until you head back to your room in the evening to find a small package waiting at your doorstep. Resting on it is another note from the Tinkerer.\n\nHe thanks you profusely for sending along the mechanical spider, saying it was a great help in his work. He doesn\'t need it any longer, however and decided to send it back.\n\nHe explains that he made a few improvements to it as well while it was in his possession, and that it should help you significantly in your adventures.',
     optionA: {
-      choice: 'Gratefully keep the spider*',
+      choice: 'Gratefully keep the spider.',
       outcome:
-        'a You open the package to find a much larger, but equally intricate robotic spider staring back at you. This one appears to specialize in scurrying around its user, picking up and returning anything that might have been dropped. Should prove use ful.\n\nGain 1 collective "Giant Remote Spider" (Item 127).',
+        'You open the package to find a much larger, but equally intricate robotic spider staring back at you. This one appears to specialize in scurrying around its user, picking up and returning anything that might have been dropped. Should prove useful.\n\nGain 1 collective "Giant Remote Spider" (Item 127).',
       imageUrl: '/assets/cards/events/base/city/ce-61-b-a.png',
     },
     optionB: {
-      choice: 'You can t decide who should keep itr so sell the spider and split the money.',
+      choice: 'You can\'t decide who should keep it, so sell the spider and split the money.',
       outcome:
-        'You head down to the Mixed District with the newly improved spider and barter with some Qua try Is who seem incredibly impressed with the craftsmanship. After some back- and-forth, you walk away with a nice sum of gold coins.\n\nGain 30 collective gold.',
+        'You head down to the Mixed District with the newly improved spider and barter with some Quatryls who seem incredibly impressed with the craftsmanship. After some back-and-forth, you walk away with a nice sum of gold coins.\n\nGain 30 collective gold.',
       imageUrl: '/assets/cards/events/base/city/ce-61-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-61-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1374,11 +1374,11 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 66,
     text:
-      "You head back to your rooms for the night when you see the Sawbones sitting in front of your doorstep, looking rather dejected. 7, uh, well, you see...” he stammers, 7 followed your advice. Chased my dreams and all that, but I ended up in debt to some rather unscrupulous people, fhey 've threatened to kill me if I don t pay them off, but, uh, but I simply don t have the money ” He hesitates. Seeing as how, uh, you bear some responsibility for setting me down this path, I was wondering if you d be willing to offer some assistance in getting me out of this mess?'",
+      "You head back to your rooms for the night when you see the Sawbones sitting in front of your doorstep, looking rather dejected.\n\n\"I, uh, well, you see...\" he stammers. \"I followed your advice. Chased my dreams and all that, but I ended up in debt to some rather unscrupulous people. They've threatened to kill me if I don't pay them off, but, uh, but I simply don't have the money.\"\n\nHe hesitates. \"Seeing as how, uh, you bear some responsibility for setting me down this path, I was wondering if you'd be willing to offer some assistance in getting me out of this mess?\"",
     optionA: {
       choice: "Offer to pay off the Sawbones' debt.",
       outcome:
-        'a PAY40 COLLECTIVE GOLD: It s a hefty * chunk of money, but the Sawbones is incredibly grateful. " This is wonderful! I knew I could count on you. This should be enough to put this mess behind me and finally allow me to live free.\' He hands you a potion and thanks you once again for all your help.\n\nGain 1 collective Super Healing Potion (Item 055).\n\nOTHERWISE: Read outcome B.',
+        'PAY 40 COLLECTIVE GOLD: It\'s a hefty chunk of money, but the Sawbones is incredibly grateful.\n\n"This is wonderful! I knew I could count on you. This should be enough to put this mess behind me and finally allow me to live free.\"\n\nHe hands you a potion and thanks you once again for all your help.\n\nGain 1 collective Super Healing Potion (Item 055).\n\nOTHERWISE: Read outcome B.',
       imageUrl: '/assets/cards/events/base/city/ce-66-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3090,17 +3090,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 67,
     text:
-      'Not too far down n* V rr miff $ VCIU outside of Gloomhaven, you run across a merchant wagon headed into town. A ht I was afraid for a second you might be banditsf" The merchant says. \' But now I see you are mercenaries from the town, correct?Most excellent! I have heard good things about the mercenaries of Gloomhaven, Hard to believe, coming from such a backwater place, but they are true, correct?* rim',
+      'Not too far down the main road outside of Gloomhaven, you run across a merchant wagon headed into town.\n\n"Ah, I was afraid for a second you might be bandits!" The merchant says. "But now I see you are mercenaries from the town, correct? Most excellent! I have heard good things about the mercenaries of Gloomhaven. Hard to believe, coming from such a backwater place, but they are true, correct?"',
     optionA: {
       choice: 'Demonstrate your virtue by offering to escort the merchant back to Gloomhaven.',
       outcome:
-        '“Ah, well...no, l don’t want to be a bother. But, I mean, yes, I can\'t pay you, though I\'d love the company. It is rather terrifying traveling the East Road by yourself." It is a relatively short journey back to town, but the merchant is very grateful. 7 am quite impressed, sirs. I ‘II be sure to tell everyone back in the capital that Gloomhaven is a safe place to do business."\n\nGain 1 prosperity.',
+        '"Ah, well...no, I don\'t want to be a bother. But, I mean, yes, I can\'t pay you, though I\'d love the company. It is rather terrifying traveling the East Road by yourself."\n\nIt is a relatively short journey back to town, but the merchant is very grateful. "I am quite impressed, sirs. I\'II be sure to tell everyone back in the capital that Gloomhaven is a safe place to do business."\n\nGain 1 prosperity.',
       imageUrl: '/assets/cards/events/base/road/re-67-b-a.png',
     },
     optionB: {
       choice: 'Demonstrate your lack of virtue by robbing the merchant.',
       outcome:
-        '"Well I just — I mean, I’d never...” the merchant trails ofTincredulously. “To think there are places in the world where such barbarism still exists. It boggles the mind. 7 m going to tell everyone back in the Capital what a horrible, backward shrrggggllg..." Blood bubbles up into his mouth as you slit his throat, making it very difficult for him to continue complaining.\n\nGain 20 gold each.',
+        '"Well I just — I mean, I\'d never..." the merchant trails of incredulously. "To think there are places in the world where such barbarism still exists. It boggles the mind.\n\n I\'m going to tell everyone back in the Capital what a horrible, backward shrrggggllg..." Blood bubbles up into his mouth as you slit his throat, making it very difficult for him to continue complaining.\n\nGain 20 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-67-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-67-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1399,7 +1399,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Pay off the thugs.',
       outcome:
-        "PAY 60 COLLECTIVE GOLD: You sigh • and hand over the Sawbones' debt, plus interest. Though it feels terrible, the thugs are satisfied and walk out the same way they came in. At least it is over now.\n\nNo effect.\n\nOTHERWISE: Seeing as how you don't have enough money, you decide pursue other options. Read outcome B.",
+        "PAY 60 COLLECTIVE GOLD: You sigh • and hand over the Sawbones' debt, plus interest. Though it feels terrible, the thugs are satisfied and walk out the same way they came in. At least it is over now.\n\nNo effect.\n\nOTHERWISE: Seeing as how you don't have enough money, you decide pursue other options.\n\nRead outcome B.",
       imageUrl: '/assets/cards/events/base/city/ce-67-b-a.png',
     },
     optionB: {
@@ -2275,7 +2275,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Sell the man a stamina potion.',
       outcome:
-        'PAY 1 COLLECTIVE "MINOR STAMINA POTION" (ITEM 013): After some oddly tense negotiations, you are able to agree upon a price. With one hand firmly on his sword hilt, the man grabs a coin pouch with the other hand and extends it toward you. You exchange goods and continue on your journey without further incident.\n\nGain 10 collective gold.\n\n{Scoundrel} {Saw} {MusicNote}: Gain 10 additional collective gold.\n\nOTHERWISE: Read outcome B.',
+        'PAY 1 COLLECTIVE "MINOR STAMINA POTION" (ITEM 013): After some oddly tense negotiations, you are able to agree upon a price. With one hand firmly on his sword hilt, the man grabs a coin pouch with the other hand and extends it toward you. You exchange goods and continue on your journey without further incident.\n\nGain 10 collective gold.\n\n{Scoundrel} {Saw} {MusicNote}: Gain 10 additional collective gold.\n\nOTHERWISE:\n\nRead outcome B.',
       imageUrl: '/assets/cards/events/base/road/re-28-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3132,17 +3132,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 69,
     text:
-      'Walking a long*the trail, you are surprised by a group of demons who appear to your left, charging over a hill toward you. Something is off however. Their pace is slow, and they are significantly smaller than the demons you normally deal with. Hallway down the hill, the demons pause and take stock of you. Seeing you are far from easy prey, they turn around and begin to retreat.',
+      'Walking along the trail, you are surprised by a group of demons who appear to your left, charging over a hill toward you. Something is off, however. Their pace is slow, and they are significantly smaller than the demons you normally deal with.\n\nHalfway down the hill, the demons pause and take stock of you. Seeing you are far from easy prey, they turn around and begin to retreat.',
     optionA: {
       choice: 'Chase them down quickly and kill them.',
       outcome:
-        'a You roar and charge up the hill[ The demons * are no match for you r either in speed or in strength. You kill them quickly, but painfully\n\nGain 5 experience each.',
+        'You roar and charge up the hill. The demons are no match for you, either in speed or in strength. You kill them quickly, but painfully.\n\nGain 5 experience each.',
       imageUrl: '/assets/cards/events/base/road/re-69-b-a.png',
     },
     optionB: {
       choice: 'Follow them more slowly, attempting to discover where they came from.',
       outcome:
-        'You creep slowly to the crest of the hill, watching as the demons retreat to the south. You follow them, eventually arriving at a weak, fluctuating rift in a small, earthen cave. Having experienced enough planar manipulation in your travels, you are able to mutter a few incantations and close the rift, ft takes a lot out of you, but now there is one less way for demons to invade this plane.\n\nLose 1 {Check} each.\n\nGain 1 prosperity.',
+        'You creep slowly to the crest of the hill, watching as the demons retreat to the south. You follow them, eventually arriving at a weak, fluctuating rift in a small, earthen cave. Having experienced enough planar manipulation in your travels, you are able to mutter a few incantations and close the rift. It takes a lot out of you, but now there is one less way for demons to invade this plane.\n\nLose 1 {Check} each.\n\nGain 1 prosperity.',
       imageUrl: '/assets/cards/events/base/road/re-69-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-69-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1290,17 +1290,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 62,
     text:
-      '\' So, I hear you stood up for me with the city guards the other day. Such annoy ing pests, aren \'t they?" You turn around in the street to see the Scoundrel emerge from a dark alley with a smile on her face. 7 just wanted to thank you in person, she says. 7 ve known quite a few persons who would have ratted me out lor their chance at a piece of gold. It s good to know some friendships last, She looks over her shoulder. *Listen, l m leaving town for a good long while, You wanna grab a drink before I take off?"',
+      '"So, I hear you stood up for me with the city guards the other day. Such annoying pests, aren\'t they?"\n\nYou turn around in the street to see the Scoundrel emerge from a dark alley with a smile on her face.\n\n"I just wanted to thank you in person," she says. "I\'ve known quite a few persons who would have ratted me out for their chance at a piece of gold. It\'s good to know some friendships last."\n\nShe looks over her shoulder. "Listen, I\'m leaving town for a good long while. You wanna grab a drink before I take off?"',
     optionA: {
       choice: 'Have a drink and reminisce about old times.',
       outcome:
-        'You faugh for a while and trade tales, ,4s the sun drops below the tavern windows, the Scoundrel gets up to leave. "Listen, I really did enjoy our time together, and, well, I just wanted to leave you with something to remember me by." A piece of black cloth flutters down onto the table. When you look back up, the Scoundrel is gone. (Item 109)- 11 Ihief s l lood',
+        'You laugh for a while and trade tales. As the sun drops below the tavern windows, the Scoundrel gets up to leave.\n\n"Listen, I really did enjoy our time together, and, well, I just wanted to leave you with something to remember me by."\n\nA piece of black cloth flutters down onto the table. When you look back up, the Scoundrel is gone.\n\nGain 1 collective "Thief\'s Hood" (Item 109).',
       imageUrl: '/assets/cards/events/base/city/ce-62-b-a.png',
     },
     optionB: {
-      choice: 'Overpower the Scoundrel and deliver her to the city guards. /',
+      choice: 'Overpower the Scoundrel and deliver her to the city guards.',
       outcome:
-        "A look of horrid surprise flashes in the Scoundrel's eyes as you leap forward and throw her to the ground. She doesn’t even speak as you bind her arms and take her to the city guard. They thank you for your service, but their words aren’t much counter to the cold\\ angry stare of the Scoundrel as she s taken away.\n\nGain 3 reputation.",
+        "A look of horrid surprise flashes in the Scoundrel's eyes as you leap forward and throw her to the ground. She doesn’t even speak as you bind her arms and take her to the city guard. They thank you for your service, but their words aren’t much counter to the cold angry stare of the Scoundrel as she\'s taken away.\n\nGain 3 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-62-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-62-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1315,13 +1315,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Agree to help.',
       outcome:
-        'The Hook Coast is outside the walls of Gloomhaven and can he a dangerous place. And since this spread of poison, the city has become even more defenseless than normal. You hope you\'ll he able to find a solution to the problem quickly. Unlock Harried Village"(86 (D-15) -',
+        'The Hook Coast is outside the walls of Gloomhaven and can be a dangerous place. And since this spread of poison, the city has become even more defenseless than normal. You hope you\'ll be able to find a solution to the problem quickly.\n\nUnlock "Harried Village" 86 (D-15).',
       imageUrl: '/assets/cards/events/base/city/ce-63-b-a.png',
     },
     optionB: {
-      choice: 'Tell the captain to fix his own problem. /',
+      choice: 'Tell the captain to fix his own problem.',
       outcome:
-        'The Captain of the Guard sighs. * 7 really thought you were the ones for the job. What business could you possibly have that is more important than making sure this city is safe?" tf He holds up his hand. "No matter. Fine, ■ just get out of here! U c will deal with this ourselves."\n\nLose 1 prosperity.\n\nLose 1 reputation.',
+        'The Captain of the Guard sighs.\n\n"I really thought you were the ones for the job. What business could you possibly have that is more important than making sure this city is safe?"\n\nHe holds up his hand. "No matter. Fine, just get out of here! We will deal with this ourselves."\n\nLose 1 prosperity.\n\nLose 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-63-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-63-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3048,11 +3048,11 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 65,
     text:
-      'As you crest a hill, you see a flock of carrion birds scatter to the east. They must have been feasting on something, so you decide to investigate. After a short walk, you come upon a mans corpse, badly decayed and mangled, lying in the dirt« His face is a bloody messf, but you do see a distinctive chain around his neck and recall the description the man from the Sleeping Lion gave you of his brother: This is very likely him.',
+      'As you crest a hill, you see a flock of carrion birds scatter to the east. They must have been feasting on something, so you decide to investigate.\n\nAfter a short walk, you come upon a man\'s corpse, badly decayed and mangled, lying in the dirt. His face is a bloody mess, but you do see a distinctive chain around his neck and recall the description the man from the Sleeping Lion gave you of his brother. This is very likely him.',
     optionA: {
       choice: 'Bury the man and bring the chain back to his brother.',
       outcome:
-        '1 Not wanting to tell the brother that you left the corpse out in the sun to rot, you take the time to Jig a hole and give it a proper burial. When you bring the chain back, the brother is understandably distraught, but he thanks you forgiving him closure about what happened.\n\nGain 2 reputation.',
+        'Not wanting to tell the brother that you left the corpse out in the sun to rot, you take the time to dig a hole and give it a proper burial.\n\nWhen you bring the chain back, the brother is understandably distraught, but he thanks you forgiving him closure about what happened.\n\nGain 2 reputation.',
       imageUrl: '/assets/cards/events/base/road/re-65-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2439,7 +2439,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 36,
     text:
-      "Up abead, you see the path you are on leads into a dark and unfamiliar wood. It gives you an eerie feeling.\n\nAs you step closer, you can feel your skin crawl and it forces you to pause, you can't help, but think that this wood might best be avoided.",
+      "Up ahead, you see the path you are on leads into a dark and unfamiliar wood. It gives you an eerie feeling.\n\nAs you step closer, you can feel your skin crawl and it forces you to pause, you can't help, but think that this wood might best be avoided.",
     optionA: {
       choice: 'Continue down the path into the wood. You are not afraid.',
       outcome:

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1505,7 +1505,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Follow the smelly old bandit.',
       outcome:
-        'Your curiosity gets the better of your judgment. You need to know the purpose of the device you found, so you follow Fish into a derelict shack where he pulls out a map of the area and lays it on a table. Fish directs you to pull out your rod and both you and he hold your respective rods over the table.\n\nA specific location on the map glows brightly ond Fish laughs. "See? I told ya, didn\'t I? Meet me there with your rod and we\'ll get rich!"\n\nUnlock "Lost Temple" 79 (K-12).\n\nParty Achievement: "Fish\'s Aid."',
+        'Your curiosity gets the better of your judgment. You need to know the purpose of the device you found, so you follow Fish into a derelict shack where he pulls out a map of the area and lays it on a table. Fish directs you to pull out your rod and both you and he hold your respective rods over the table.\n\nA specific location on the map glows brightly and Fish laughs. "See? I told ya, didn\'t I? Meet me there with your rod and we\'ll get rich!"\n\nUnlock "Lost Temple" 79 (K-12).\n\nParty Achievement: "Fish\'s Aid."',
       imageUrl: '/assets/cards/events/base/city/ce-72-b-a.png',
     },
     optionB: {
@@ -1522,17 +1522,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 73,
     text:
-      'You awake in your bed to sen- sation of someone shaking you, but when you look around, you see no one else in your room. Instead[ you see that it s the entire room that s shaking. Your thoughts immediately go to the crystal you found inside the mountain along the road[ You quickly search through your belongings and grab the crystal in your hand. The earth- quake immediately stops« C fearly this thing has some power and you need to deal with it before more damage is done.',
+      'You awake in your bed to sensation of someone shaking you, but when you look around, you see no one else in your room. Instead, you see that it\'s the entire room that\'s shaking.\n\nYour thoughts immediately go to the crystal you found inside the mountain along the road. You quickly search through your belongings and grab the crystal in your hand. The earthquake immediately stops.\n\nClearly this thing has some power and you need to deal with it before more damage is done.',
     optionA: {
       choice: 'Seek help from the University.',
       outcome:
-        "“Yes, very interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold.\n\nUnlock \"Crystalline Cave\" 84 (D-12).\n\nParty Achievement: \"Tremors.\"",
+        '"Yes, very interesting," a bookish Quatryl says as he rolls the crystal over in his hand. "It seems as if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I\'d say you need to return it to its proper home. With the proper tools — which I\'ll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold.\n\nUnlock "Crystalline Cave" 84 (D-12).\n\nParty Achievement: "Tremors."',
       imageUrl: '/assets/cards/events/base/city/ce-73-b-a.png',
     },
     optionB: {
       choice: 'Throw the crystal into the bay.',
       outcome:
-        'Not wanting to waste your time with the problem, you walk to the Jocks anJ throw the crystal into the bay. When you hear reports of harsher weather anJ larger waves hitting the Jocks, you try not to pay them any mind.\n\nLose 1 prosperity.',
+        'Not wanting to waste your time with the problem, you walk to the docks and throw the crystal into the bay. When you hear reports of harsher weather and larger waves hitting the docks, you try not to pay them any mind.\n\nLose 1 prosperity.',
       imageUrl: '/assets/cards/events/base/city/ce-73-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-73-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -70,7 +70,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 4,
     text:
-      'Having recently returned from your latest adventure, you are approached by a ratty-looking boy in tears.\n\n"Please, sirs, could you please help me with my cat? He went over there, and I’m afraid." The boy points a dirty finger at a decrepit, abandoned building. "I don\'t know what else to do."',
+      'Having recently returned from your latest adventure, you are approached by a ratty-looking boy in tears.\n\n"Please, sirs, could you please help me with my cat? He went over there, and I\'m afraid." The boy points a dirty finger at a decrepit, abandoned building. "I don\'t know what else to do."',
     optionA: {
       choice: 'Find a cat? You have more important things to do.',
       outcome:
@@ -747,13 +747,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Join the fray! These insults will not go unanswered!',
       outcome:
-        "{LightningBolts}: You break a chair over the man's back, kick him in the teeth, and then you really get into it. It's a bar brawl that could only be described as \"epic\" fueled by pure, raw rage. The carnage is extreme.\n\nGain 5 experience each.\n\nLose 2 reputation.\n\nOTHERWISE: You jump into the melee, breaking heads and chairs in equal measure. You’ve seen worse brawls, but the proprietor still isn’t very happy when it’s over.\n\nLose 1 reputation.",
+        "{LightningBolts}: You break a chair over the man's back, kick him in the teeth, and then you really get into it. It's a bar brawl that could only be described as \"epic\" fueled by pure, raw rage. The carnage is extreme.\n\nGain 5 experience each.\n\nLose 2 reputation.\n\nOTHERWISE: You jump into the melee, breaking heads and chairs in equal measure. You've seen worse brawls, but the proprietor still isn't very happy when it's over.\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-36-b-a.png',
     },
     optionB: {
       choice: 'Do your best to stop the fighting. This is a respectable establishment.',
       outcome:
-        '{LightningBolts}: You get up to calm down the room, but the Berserker has other ideas, laying into the man before you can get a word out. She goes into a furious rage, and there’s really not much to be done about it except pay what you can for the damages afterward.\n\nLose 10 collective gold.\n\nOTHERWISE: It takes some work, but you manage to calm down the Inox and buy off the rest of the room with some extra drinks. The proprietor looks positively relieved.\n\nGain 1 reputation.',
+        '{LightningBolts}: You get up to calm down the room, but the Berserker has other ideas, laying into the man before you can get a word out. She goes into a furious rage, and there\'s really not much to be done about it except pay what you can for the damages afterward.\n\nLose 10 collective gold.\n\nOTHERWISE: It takes some work, but you manage to calm down the Inox and buy off the rest of the room with some extra drinks. The proprietor looks positively relieved.\n\nGain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-36-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-36-f.png',
@@ -768,11 +768,11 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Attempt to console and cheer up those affected by the attack.',
       outcome:
-        "{MusicNote}: The citizens are downtrodden, but the uncanny power of the Soothsinger’s music seems to lift their spirits considerably. Still far from cheerful, the people find new resolve in repairing the damage and rebuilding.\n\nGain 1 prosperity.\n\nOTHERWISE: The citizens view you with a cynical eye as you walk around, attempting to encourage them and lift their spirits. Despite the effort, it seems as though they are in a worse mood than when you arrived.\n\nLose 1 reputation.",
+        "{MusicNote}: The citizens are downtrodden, but the uncanny power of the Soothsinger's music seems to lift their spirits considerably. Still far from cheerful, the people find new resolve in repairing the damage and rebuilding.\n\nGain 1 prosperity.\n\nOTHERWISE: The citizens view you with a cynical eye as you walk around, attempting to encourage them and lift their spirits. Despite the effort, it seems as though they are in a worse mood than when you arrived.\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-37-b-a.png',
     },
     optionB: {
-      choice: 'Help repair the gate. You wouldn’t want another attack to further cripple the town.',
+      choice: 'Help repair the gate. You wouldn\'t want another attack to further cripple the town.',
       outcome:
         '{ThreeSpears} {Spellweaver} {Tinkerer} {Triangles} {Circles}: You set to work repairing the gate, and by the time night falls, it is at least functional. The downtrodden citizens are inspired by your work, and you have little doubt that the community will bounce bock with little permanent damage.\n\nGain 1 prosperity.\n\nOTHERWISE: You fiddle with the gate for a bit until it becomes clear that you are doing nothing to help. You decide to head back to your rooms instead and get some rest.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-37-b-b.png',
@@ -849,11 +849,11 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 41,
     text:
-      'The Sinking Market is a varied area or decrepit huts and merchants unable to sell their wares anywhere else. It doesn\'t surprise you as you walk through to see a scraggly Vermling approach with a small sack.\n\n"A potion for the big, strong adventurers!" she says as she waves you down. “Help you in battle, it will!"\n\nYou are about to push her aside and keep walking when she pulls the potion out of the sack. It glows green in the daylight — an impressive, large flask of master craftsmanship.\n\n"Aha, I knew it catch your eye! How much you pay?"',
+      'The Sinking Market is a varied area or decrepit huts and merchants unable to sell their wares anywhere else. It doesn\'t surprise you as you walk through to see a scraggly Vermling approach with a small sack.\n\n"A potion for the big, strong adventurers!" she says as she waves you down. \"Help you in battle, it will!"\n\nYou are about to push her aside and keep walking when she pulls the potion out of the sack. It glows green in the daylight — an impressive, large flask of master craftsmanship.\n\n"Aha, I knew it catch your eye! How much you pay?"',
     optionA: {
       choice: 'Barter with the Vermling for the potion.',
       outcome:
-        '{TwoMinis}, PAY 10 COLLECTIVE GOLD: The Vermling knows it is valuable, but she is more interested in flirting with the Beast Tyrant. She is happy to sell the potion at a discount.\n\nGain 1 collective “Major Stamina Potion" (Item 034)\n\nPAY 25 COLLECTIVE GOLD: No amount of haggling can lower the Vermling\'s high price.\n\nGain 1 collective "Major Stamina Potion" (Item 034).\n\nOTHERWISE: The Vermling will not accept the tiny sum you offer. Maybe next time.',
+        '{TwoMinis}, PAY 10 COLLECTIVE GOLD: The Vermling knows it is valuable, but she is more interested in flirting with the Beast Tyrant. She is happy to sell the potion at a discount.\n\nGain 1 collective \"Major Stamina Potion" (Item 034)\n\nPAY 25 COLLECTIVE GOLD: No amount of haggling can lower the Vermling\'s high price.\n\nGain 1 collective "Major Stamina Potion" (Item 034).\n\nOTHERWISE: The Vermling will not accept the tiny sum you offer. Maybe next time.',
       imageUrl: '/assets/cards/events/base/city/ce-41-b-a.png',
     },
     optionB: {
@@ -870,11 +870,11 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 42,
     text:
-      'Walking near the West Gate, you are approached by a scrawny kid in a guard uniform, which is clearly too big for his small frame.\n\n"Hey, you all are famous!" he says with a big smile. "I worked as a caravan guard before I got this job. Met with a big Inox guy who always talked about you. He made you seem like the nicest, most amazing people."\n\nHis smile and excitement doesn’t waver. "Say, my detail is doing some work to repair the wall damage from the last Vermling attack. Would you mind helping us! It\'ll be fun!"',
+      'Walking near the West Gate, you are approached by a scrawny kid in a guard uniform, which is clearly too big for his small frame.\n\n"Hey, you all are famous!" he says with a big smile. "I worked as a caravan guard before I got this job. Met with a big Inox guy who always talked about you. He made you seem like the nicest, most amazing people."\n\nHis smile and excitement doesn\'t waver. "Say, my detail is doing some work to repair the wall damage from the last Vermling attack. Would you mind helping us! It\'ll be fun!"',
     optionA: {
       choice: 'Agree to help the presumptuous kid.',
       outcome:
-        "It's hard work, but the kid's enthusiasm is infectious. He wants to know all about your exploits and adventures, and he and his detail prove to be a great audience. By the end of the day, it hardly feels like you’ve worked at all.\n\nGain 1 prosperity.\n\nGain 1 reputation.",
+        "It's hard work, but the kid's enthusiasm is infectious. He wants to know all about your exploits and adventures, and he and his detail prove to be a great audience. By the end of the day, it hardly feels like you\'ve worked at all.\n\nGain 1 prosperity.\n\nGain 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-42-b-a.png',
     },
     optionB: {
@@ -891,7 +891,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 43,
     text:
-      'You return to your rooms for the evening to find a small note resting on the ground in front of your door.\n\nIt is from the Tinkerer, explaining that he has been pursuing further studies in flammable liquid delivery methods. He asks for your help in delivering to him a small robotic contraption that he absentmindedlv left behind in a secret stash under the floorboards of his old room.\n\nHe details the device’s location and gives an address to deliver it to some small village far to the northwest.',
+      'You return to your rooms for the evening to find a small note resting on the ground in front of your door.\n\nIt is from the Tinkerer, explaining that he has been pursuing further studies in flammable liquid delivery methods. He asks for your help in delivering to him a small robotic contraption that he absentmindedlv left behind in a secret stash under the floorboards of his old room.\n\nHe details the device\'s location and gives an address to deliver it to some small village far to the northwest.',
     optionA: {
       choice: 'Oblige the Tinkerer and send along the contraption.',
       outcome:
@@ -975,17 +975,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 47,
     text:
-      'Walking near Gloomhaven Square, you see a peculiar scene. A group of guards is dragging along a Vermling in tattered robes toward the Ghost Fortress. Getting a little closer, you recognise the Mindthief.\n\n"Hssss," she spits. "Why do you do this? I came to you! I tell you that this town is being poisoned, and you respond by imprisoning me?"\n\n"Well see what the Captain of the Guard has to say about this," one of her captors says. “Keep moving!"',
+      'Walking near Gloomhaven Square, you see a peculiar scene. A group of guards is dragging along a Vermling in tattered robes toward the Ghost Fortress. Getting a little closer, you recognise the Mindthief.\n\n"Hssss," she spits. "Why do you do this? I came to you! I tell you that this town is being poisoned, and you respond by imprisoning me?"\n\n"Well see what the Captain of the Guard has to say about this," one of her captors says. "Keep moving!"',
     optionA: {
       choice: 'Intervene with the guards and find out what is going on.',
       outcome:
-        "The guards look incredibly perturbed when you step in front of them and ask that they leave the Mindthief to you. After some effort, they begrudgingly hand her over. The Mindthief thanks you, explaining that her colony in the sewers is being poisoned, and the poison is quickly migrating to the city's water supply. She says she’s tracked the source to a small cove along the Hook Coast.\n\nLose 1 reputation.\n\nUnlock \"Corrupted Cove\" 87 (I-9).\n\nParty Achievement: \"The Poison's Source.\"",
+        "The guards look incredibly perturbed when you step in front of them and ask that they leave the Mindthief to you. After some effort, they begrudgingly hand her over. The Mindthief thanks you, explaining that her colony in the sewers is being poisoned, and the poison is quickly migrating to the city's water supply. She says she's tracked the source to a small cove along the Hook Coast.\n\nLose 1 reputation.\n\nUnlock \"Corrupted Cove\" 87 (I-9).\n\nParty Achievement: \"The Poison's Source.\"",
       imageUrl: '/assets/cards/events/base/city/ce-47-b-a.png',
     },
     optionB: {
       choice: 'Let the guards continue their business and just continue with yours.',
       outcome:
-        "The Mindthief flicks her tail and throws insults around, but it doesn't seem to have any positive effect. She is led away and out of view. You get about your business, hoping that bit about the town being poisoned wasn’t too serious.\n\nAdd City Event 63 to the deck.",
+        "The Mindthief flicks her tail and throws insults around, but it doesn't seem to have any positive effect. She is led away and out of view. You get about your business, hoping that bit about the town being poisoned wasn't too serious.\n\nAdd City Event 63 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-47-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-47-f.png',
@@ -1088,7 +1088,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-52-b-a.png',
     },
     optionB: {
-      choice: 'Threaten the Plagueherald with retribution if it doesn’t stop attacking residents.',
+      choice: 'Threaten the Plagueherald with retribution if it doesn\'t stop attacking residents.',
       outcome:
         'The Plagueherald recoils at your threat, genuinely concerned that you would attack it.\n\n"But, the cleansing...the city isn\'t ready."\n\nYou shake your head, and the Harrower chitters in disappointment.\n\n"Very well, but you will be responsible when the Harbinger comes." It turns and floats off into the darkness.\n\nGain 1 prosperity.',
       imageUrl: '/assets/cards/events/base/city/ce-52-b-b.png',
@@ -1206,7 +1206,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 58,
     text:
-      '"There were fifty of them, I swear. Tearing my mates apart!"\n\nYou look over to the bar where a group of drunkards are all laughing at a disheveled man in the middle of a story.\n\n"And commanding them all riding atop a giant armored bear, there was a Vermling with a staff that shot lightning!"\n\nAt this the crowd erupts into more laughter, drowning out the rest of the man\'s story.\n\n"This man\'s had too much to drink, I\'d say," ridicules one of the crowd. "Vermlings riding bears! I thought I’d heard of everything!"',
+      '"There were fifty of them, I swear. Tearing my mates apart!"\n\nYou look over to the bar where a group of drunkards are all laughing at a disheveled man in the middle of a story.\n\n"And commanding them all riding atop a giant armored bear, there was a Vermling with a staff that shot lightning!"\n\nAt this the crowd erupts into more laughter, drowning out the rest of the man\'s story.\n\n"This man\'s had too much to drink, I\'d say," ridicules one of the crowd. "Vermlings riding bears! I thought I\'d heard of everything!"',
     optionA: {
       choice: 'Join the crowd in laughing at the man.',
       outcome:
@@ -1300,7 +1300,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Overpower the Scoundrel and deliver her to the city guards.',
       outcome:
-        "A look of horrid surprise flashes in the Scoundrel's eyes as you leap forward and throw her to the ground. She doesn’t even speak as you bind her arms and take her to the city guard. They thank you for your service, but their words aren’t much counter to the cold angry stare of the Scoundrel as she\'s taken away.\n\nGain 3 reputation.",
+        "A look of horrid surprise flashes in the Scoundrel's eyes as you leap forward and throw her to the ground. She doesn't even speak as you bind her arms and take her to the city guard. They thank you for your service, but their words aren't much counter to the cold angry stare of the Scoundrel as she\'s taken away.\n\nGain 3 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-62-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-62-f.png',
@@ -1589,7 +1589,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Accept the drink.',
       outcome:
-        'REPUTATION > 14: "Excellent! Someone has been attacking my ships at sea and I need to get to the bottom of it. Come, I’ll tell you the details."\n\nUnlock "Merchant Ship" 74 (I-14).\n\nParty Achievement: "High Sea Escort."\n\nOTHERWISE: "Oh. whoops." Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\n\nNo effect.',
+        'REPUTATION > 14: "Excellent! Someone has been attacking my ships at sea and I need to get to the bottom of it. Come, I\'ll tell you the details."\n\nUnlock "Merchant Ship" 74 (I-14).\n\nParty Achievement: "High Sea Escort."\n\nOTHERWISE: "Oh. whoops." Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-76-b-a.png',
     },
     optionB: {
@@ -2065,7 +2065,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Attempt to come to a peaceful resolution.',
       outcome:
-        'REPUTATION < -4: You begin to agree with the Inox that Gloomhaven is a blight on the land in need of cleansing, and the Inox seems to believe you. "Go in peace, then," the leader says. “And stay off my land."\n\nNo effect.\n\nOTHERWISE: You try to explain that you mean the Inox no ill will, but the leader eyes you skeptically. "Foul creature. I curse you and your kind! Run — get off my land and never come back!"\n\nAll start scenario with {Curse}.',
+        'REPUTATION < -4: You begin to agree with the Inox that Gloomhaven is a blight on the land in need of cleansing, and the Inox seems to believe you. "Go in peace, then," the leader says. "And stay off my land."\n\nNo effect.\n\nOTHERWISE: You try to explain that you mean the Inox no ill will, but the leader eyes you skeptically. "Foul creature. I curse you and your kind! Run — get off my land and never come back!"\n\nAll start scenario with {Curse}.',
       imageUrl: '/assets/cards/events/base/road/re-18-b-a.png',
     },
     optionB: {
@@ -2611,7 +2611,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Renew your efforts to slay the demons.',
       outcome:
-        'With the help of the mysterious firecaster, the battle turns and the demons are slain without much pain. Out of the darkness steps the familiar face of a female Orchid.\n\n"Sorry about that. I think they were looking for this." The Spell weaver holds up a black censer. "It\'s a good thing I ran into you, though. I could use your help."\n\nShe draws out a crude map. "Meet me here as soon as you can, and I’ll explain more."\n\nUnlock "Demonic Rift" 90 (J-7).',
+        'With the help of the mysterious firecaster, the battle turns and the demons are slain without much pain. Out of the darkness steps the familiar face of a female Orchid.\n\n"Sorry about that. I think they were looking for this." The Spell weaver holds up a black censer. "It\'s a good thing I ran into you, though. I could use your help."\n\nShe draws out a crude map. "Meet me here as soon as you can, and I\'ll explain more."\n\nUnlock "Demonic Rift" 90 (J-7).',
       imageUrl: '/assets/cards/events/base/road/re-44-b-a.png',
     },
     optionB: {
@@ -2628,7 +2628,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 45,
     text:
-      "Riding up on horses, a band of dirty, rough men quickly overtake and surround your group. They look hard and dangerous, and you immediately pull out your weapons as they approach.\n\nThen you hear a familiar laugh.\n\n\"Well, if it isn't my old crew.\" A woman in dark leather armor leaps off her horse to comes greet you. \"You know whatt boys? This lot gets a pass.\"\n\nShe winks at you and turns around. \"Plus, they’d probably kill you all if things turned ugly.\"\n\nJumping back onto her horse, the Scoundrel looks back at you. \"Well, it was nice seeing you. Just remember — you never saw me.\"",
+      "Riding up on horses, a band of dirty, rough men quickly overtake and surround your group. They look hard and dangerous, and you immediately pull out your weapons as they approach.\n\nThen you hear a familiar laugh.\n\n\"Well, if it isn't my old crew.\" A woman in dark leather armor leaps off her horse to comes greet you. \"You know whatt boys? This lot gets a pass.\"\n\nShe winks at you and turns around. \"Plus, they'd probably kill you all if things turned ugly.\"\n\nJumping back onto her horse, the Scoundrel looks back at you. \"Well, it was nice seeing you. Just remember — you never saw me.\"",
     optionA: {
       choice: 'Attack. Friend or not, those who prey on the weak should be brought to justice.',
       outcome:
@@ -2716,7 +2716,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Claim allegiance to the military.',
       outcome:
-        'The armored men seem satisfied with your response and take their hands off their weapons.\n\n"Good to find some fellow patriots,” the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties.\n\nUnlock "Vigil Keep" 80 (K-1).',
+        'The armored men seem satisfied with your response and take their hands off their weapons.\n\n"Good to find some fellow patriots," the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties.\n\nUnlock "Vigil Keep" 80 (K-1).',
       imageUrl: '/assets/cards/events/base/road/re-49-b-a.png',
     },
     optionB: {
@@ -2758,7 +2758,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Investigate further.',
       outcome:
-        "You get closer to the pike. The skull looks pretty fresh. There are still bits of decayed flesh attached to the bone, and flies buzz around it. You can see there is a small paper card stuck in its mouth so you carefully reach in and pull it out. The card is black and depicts a skull with blades running through it. Come to think of it you remember rumors of an assassins' guild that has been known to use the same imagery You get out of the area as quickly as you can.\n\nGain 1 collective “Black Card” (Item 129).",
+        "You get closer to the pike. The skull looks pretty fresh. There are still bits of decayed flesh attached to the bone, and flies buzz around it. You can see there is a small paper card stuck in its mouth so you carefully reach in and pull it out. The card is black and depicts a skull with blades running through it. Come to think of it you remember rumors of an assassins' guild that has been known to use the same imagery You get out of the area as quickly as you can.\n\nGain 1 collective \"Black Card\" (Item 129).",
       imageUrl: '/assets/cards/events/base/road/re-51-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1441,7 +1441,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Embrace the joke and go with it.',
       outcome:
-        'You nuke your way to the front of the crowd and join in the fun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus, ft s a lit tie embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
+        'You make your way to the front of the crowd and join in the fun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus, ft s a lit tie embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-69-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2733,17 +2733,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 50,
     text:
-      'Up ahead of you, you see a staff7 stuck in the very center of the road pointing straight up out of the ground You get closer, and an odd sense of foreboding comes ove you. You recognize the staff as the one wielded by the Summoner The fact that it now in front ofyou with w such a strange and ominous placement makes you very wary. You quickly look around, Lwt nothing else of note is in sight.',
+      'Up ahead of you, you see a staff stuck in the very center of the road pointing straight up out of the ground. You get closer, and an odd sense of foreboding comes over you.\n\nYou recognize the staff as the one wielded by the Summoner. The fact that it is now in front of you with such a strange and ominous placement makes you very wary.\n\nYou quickly look around, but nothing else of note is in sight.',
     optionA: {
       choice: 'Take the staff and move on.',
       outcome:
-        "-'v'V*'\t;! You shrug and grab the staff, half expecting • something exciting to happen when you do. Instead, nothing happens at all. In fact, the staff seems rather mundane. You feel no power running through it at all. Still, no sense in leaving it behind. It could be important.\n\nAdd City Event 68 to the deck.",
+        'You shrug and grab the staff, half expecting something exciting to happen when you do. Instead, nothing happens at all. In fact, the staff seems rather mundane. You feel no power running through it at all. Still, no sense in leaving it behind. It could be important.\n\nAdd City Event 68 to the deck.',
       imageUrl: '/assets/cards/events/base/road/re-50-b-a.png',
     },
     optionB: {
       choice: 'Investigate the area and get to the bottom of this.',
       outcome:
-        'You spend a good hour looking over (he area, scouring every bush dm! divot you can find. Unfortunately, you find no other clues about what happened here and end up fust tiring yourself out.\n\nDiscard 2 cards each.\n\nRead outcome A.',
+        'You spend a good hour looking over the area, scouring every bush and divot you can find. Unfortunately, you find no other clues about what happened here and end up just tiring yourself out.\n\nDiscard 2 cards each.\n\nRead outcome A.',
       imageUrl: '/assets/cards/events/base/road/re-50-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-50-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2985,17 +2985,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 62,
     text:
-      'By now, the Sun Demons cut a very recognizable portrait against the horizon as they move toward you. You sincerely had hoped you were done with these creatures. h\t■\tf\t-m "We have urgent need of your assistance, one of them starts. *Night Demons have infested the Sun Temple* attempting to desecrate it and send the world into eternal darkness. "We have tried to stop them, but they are too fortified inside the temple. We regrettably need more $t rength. "Please, you cannot want an absence of a sun on this plane any less than we do. It would be disastrous.',
+      'By now, the Sun Demons cut a very recognizable portrait against the horizon as they move toward you. You sincerely had hoped you were done with these creatures.\n\n"We have urgent need of your assistance," one of them starts. "Night Demons have infested the Sun Temple, attempting to desecrate it and send the world into eternal darkness.\n\n"We have tried to stop them, but they are too fortified inside the temple. We regrettably need more strength.\n\n"Please, you cannot want an absence of a sun on this plane any less than we do. It would be disastrous.\"',
     optionA: {
-      choice: 'Agree to help the Sim Demons,',
+      choice: 'Agree to help the Sun Demons.',
       outcome:
-        'r 1 You sigh ami agree, warning them that this had better be the last time they ask you for a favor. They give you the location of the Sun Temple and implore you to hurry.',
+        'You sigh and agree, warning them that this had better be the last time they ask you for a favor. They give you the location of the Sun Temple and implore you to hurry.\n\nUnlock \"Sun Temple\" 85 (M-3)',
       imageUrl: '/assets/cards/events/base/road/re-62-b-a.png',
     },
     optionB: {
       choice: 'Attack the Sun Demons. It may be the only way to stop them from bothering you.',
       outcome:
-        'Without even speaking, you draw your weapons and attack. The demons are caught offguard, but they bounce back with great ferocity, ft is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}/\n\nAll start scenario with 3 damage.',
+        'Without even speaking, you draw your weapons and attack. The demons are caught off guard, but they bounce back with great ferocity. It is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}/\n\nAll start scenario with 3 damage.',
       imageUrl: '/assets/cards/events/base/road/re-62-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-62-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2922,17 +2922,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 59,
     text:
-      'The\tair is especially humid and muggy as you walk towards your destination, but even that couldn’t explain the sight that greets you on the road. Directly in Iront of you, completely blocking the only available path, is a massive swarm of insects. There must be millions of them. >bt/ take a hesitant step forward and the bugs do not react. They are not concerned by your presence at all. — w    \t■&» ■». m« mwi',
+      'The air is especially humid and muggy as you walk towards your destination, but even that couldn\'t explain the sight that greets you on the road.\n\nDirectly in front of you, completely blocking the only available path, is a massive swarm of insects. There must be millions of them.\n\nYou take a hesitant step forward and the bugs do not react. They are not concerned by your presence at all.',
     optionA: {
       choice: 'Cover yourself as best you can and try to walk through the swarm.',
       outcome:
-        'If you were to list the top ten worst moments • of your fife, this would probably be up there. You walk into the swarm and the insects are everywhere, biting and clawing at your flesh. You move as quickly as you can, emerging from the other side with your life intact, but your sanity in shambles. Oddly though, you also feel as though you were just in the presence of a powerful, divine force.\n\nAll start scenario with 2 damage.\n\nAll start scenario with {Poison}, {Muddle}, and {Bless}.',
+        'If you were to list the top ten worst moments of your fife, this would probably be up there. You walk into the swarm and the insects are everywhere, biting and clawing at your flesh. You move as quickly as you can, emerging from the other side with your life intact but your sanity in shambles. Oddly, though, you also feel as though you were just in the presence of a powerful, divine force.\n\nAll start scenario with 2 damage.\n\nAll start scenario with {Poison}, {Muddle}, and {Bless}.',
       imageUrl: '/assets/cards/events/base/road/re-59-b-a.png',
     },
     optionB: {
       choice: 'Use whatever you can to burn a path through the swarm.',
       outcome:
-        'It takes a monumental effort, but you are eventually able to disperse the cloud of insects enough to run through to the other side. As you do so, ho we vcr. you hear an odd voice among the buzzing, cursing you for your violent actions.\n\nDiscard 2 cards each.\n\nAll start scenario with {Curse}.',
+        'It takes a monumental effort, but you are eventually able to disperse the cloud of insects enough to run through to the other side. As you do so, however. you hear an odd voice among the buzzing, cursing you for your violent actions.\n\nDiscard 2 cards each.\n\nAll start scenario with {Curse}.',
       imageUrl: '/assets/cards/events/base/road/re-59-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-59-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1690,7 +1690,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 81,
     text:
-      '"Hey aren\'t you the mercenaries who stopped that weird tornado from destroying the city?"\n\nYou turn to see a dirty dock worker pointing at you with wonder in his eyes. What was that all about anyway?"\n\nMore people stop and stare at you. This has become and unfortunately common occurrence since the Gloom was destroyed. You have become something of a minor celebrity in Gloomhaven.',
+      '"Hey aren\'t you the mercenaries who stopped that weird tornado from destroying the city?"\n\nYou turn to see a dirty dock worker pointing at you with wonder in his eyes. "What was that all about anyway?"\n\nMore people stop and stare at you. This has become and unfortunately common occurrence since the Gloom was destroyed. You have become something of a minor celebrity in Gloomhaven.',
     optionA: {
       choice: 'Take the time to relate the story of what happened.',
       outcome:

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -390,7 +390,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Attend the wedding with an expensive gift.',
       outcome:
-        'REPUTATION > 9, PAY 20 COLLECTIVE GOLD: You head to the New Market and find a magnificent vase to bring as a gift. When the father of the bride sees it, he declares it the most wonderful piece he\'s ever encountered. You are the talk of the town.\n\nGain 2 reputation.\n\nREPUTATION < 10, PAY 20 COLLECTIVE GOLD: You bring a very expensive vase as a gift, but you can\'t seem to catch the father of the bride\'s eve to present it at the right time.\n\nNo effect.\n\nOTHERWISE: Read outcome B.',
+        'REPUTATION > 9, PAY 20 COLLECTIVE GOLD: You head to the New Market and find a magnificent vase to bring as a gift. When the father of the bride sees it, he declares it the most wonderful piece he\'s ever encountered. You are the talk of the town.\n\nGain 2 reputation.\n\nREPUTATION < 10, PAY 20 COLLECTIVE GOLD: You bring a very expensive vase as a gift, but you can\'t seem to catch the father of the bride\'s eve to present it at the right time.\n\nNo effect.\n\nOTHERWISE:\n\nRead outcome B.',
       imageUrl: '/assets/cards/events/base/city/ce-19-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1610,7 +1610,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Do the job.',
       outcome:
-        'REPUTATION < -14 "That\'s the money-loving criminals I know and love! Come take a walk with me, and I\'ll explain how we can all get rich."\n\nUnlock "Overgrown Graveyard" 75 (G-12).\n\nParty Achievement: "Grave Job."\n\nOTHERWISE: "Oh, whoops," Nick stammers. "From the back you looked like...uh, never mind. Forget I said anything."\n\nNo effect.',
+        'REPUTATION < -14\n\n"That\'s the money-loving criminals I know and love! Come take a walk with me, and I\'ll explain how we can all get rich."\n\nUnlock "Overgrown Graveyard" 75 (G-12).\n\nParty Achievement: "Grave Job."\n\nOTHERWISE: "Oh, whoops," Nick stammers. "From the back you looked like...uh, never mind. Forget I said anything."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1564,17 +1564,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 75,
     text:
-      'Returning to Gloomhaven af- ter your latest outing, you are ap- proached by the Captain of the Guard at the city gates. “Ah, I was hoping I might catch you here soon- er or later," he says. 7 have still been receiving reports about large, flying lizards from the scouts. Tell me, have you gotten to the bottom of that situation yet?"',
+      'Returning to Gloomhaven after your latest outing, you are approached by the Captain of the Guard at the city gates.\n\n"Ah, I was hoping I might catch you here sooner or later," he says. "I have still been receiving reports about large, flying lizards from the scouts. Tell me, have you gotten to the bottom of that situation yet?"',
     optionA: {
       choice: 'Lie and say that you are still working on it.',
       outcome:
-        '"Oh, hmm...well, that\'s disappointing The Captain looks at you with dejected frustration. “Ifyou could, please look into the sightings as soon as you can. I d hate to think of some giant living creature attacking the city."\n\nLose 1 reputation.',
+        '"Oh, hmm...well, that\'s disappointing." The Captain looks at you with dejected frustration. "If you could, please look into the sightings as soon as you can. I\'d hate to think of some giant living creature attacking the city."\n\nLose 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-75-b-a.png',
     },
     optionB: {
       choice: 'Tell the Captain you decided not to kill the Elder Drake.',
       outcome:
-        '"Oh, my...well, okay." The Captain looks at you with stunned curiosity. "So there is a massive, fire-breathing drake up in the moun- tains, and you decided there was no reason to kill it? Interesting." The Captain wanders off. mumbling about needing to find better help.\n\nLose 2 reputation.',
+        '"Oh, my...well, okay." The Captain looks at you with stunned curiosity. "So there is a massive, fire-breathing drake up in the mountains, and you decided there was no reason to kill it? Interesting."\n\nThe Captain wanders off, mumbling about needing to find better help.\n\nLose 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-75-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-75-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1311,7 +1311,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 63,
     text:
-      '7 assume you are aware of an increased amount of sickness in the * city. )ou were summoned to the Ghost fortress and now stand before the Captain ot the Guard, "ItV believe it could have something to do with a poisoning threat brought to our attention by your Mindthief friend a while ago. We ignored it, but now she is nowhere to he found, the Hook Coast is a bed of disease, and Gloomhaven proper is on its way there, too. He looks at you firmly. “I need you to head dow n to the Hook Coast and figure out what is going on. Then eliminate the source of the poison.',
+      '"I assume you are aware of an increased amount of sickness in the city."\n\nYou were summoned to the Ghost Fortress and now stand before the Captain of the Guard.\n\n"We believe it could have something to do with a poisoning threat brought to our attention by your Mindthief friend a while ago. We ignored it, but now she is nowhere to be found, the Hook Coast is a bed of disease, and Gloomhaven proper is on its way there, too."\n\nHe looks at you firmly. "I need you to head down to the Hook Coast and figure out what is going on. Then eliminate the source of the poison."',
     optionA: {
       choice: 'Agree to help.',
       outcome:
@@ -1340,7 +1340,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-64-b-a.png',
     },
     optionB: {
-      choice: 'Claim you want nothing to do with this and walk away. /',
+      choice: 'Claim you want nothing to do with this and walk away.',
       outcome:
         "*The Sin-Ra Syndicate seems to think you have something to do with this/ the Nightshroudyells at you as you leave. That s alt that matters! They II strike again, and I won 't be there to protect you!” You keep walking.\n\naAdd Road Event 64 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-64-b-b.png',
@@ -1353,7 +1353,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 65,
     text:
-      "In the middle of the night, you tire wakened by a hard knocking at your door. You answer and it takes you *\tv a second to recognize the man standing on the other side. t hose Oak relics you was look in for, the man J\t* says as he scratches a blister on the side of his lace. Some cut purses tried to sell them to me. I can take you to their place, but we gotta move fast, and / want a cut of the loot. ” You hurriedly agree and make your way to a ramshackle warehouse next to the old docks. ' This is it/' the man says. \"Looks like no one s V* home, though/",
+      "In the middle of the night, you tire wakened by a hard knocking at your door. You answer and it takes you *\tv a second to recognize the man standing on the other side. t hose Oak relics you was look in for, the man J\t* says as he scratches a blister on the side of his lace. Some cut purses tried to sell them to me. I can take you to their place, but we gotta move fast, and I want a cut of the loot. ” You hurriedly agree and make your way to a ramshackle warehouse next to the old docks. ' This is it/' the man says. \"Looks like no one s V* home, though/",
     optionA: {
       choice: 'Raid the warehouse and recover the stolen goods.',
       outcome:
@@ -1382,7 +1382,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-66-b-a.png',
     },
     optionB: {
-      choice: 'Get the Sawbones on a boat across the Misty Sea. New adventures surely await there. /',
+      choice: 'Get the Sawbones on a boat across the Misty Sea. New adventures surely await there.',
       outcome:
         "You flatly refuse to pay off the Sawbones' debt and convince him the only way to escape his pursuers is to board a ship bound for the eastern continent, far out of their reach. He is reluctant but eventually agrees when you remind him what unknown adventures await in the land across the ocean. You see him off in the night and desperately hope that is the last you hear of this situation.\n\nAdd City Event 67 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-66-b-b.png',
@@ -1403,7 +1403,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-67-b-a.png',
     },
     optionB: {
-      choice: 'Refuse to pay. You won t be strong- armed by anyone. A /',
+      choice: 'Refuse to pay. You won\'t be strongarmed by anyone.',
       outcome:
         'You laugh and wave your hand dismissively. I here \'s no way you will be paying such a large amount of money to these thugs. Unfortunately, the Inox is not amused. m " Then your payment will he blood! she says "Meet us in the back alley, and ivc \'ll see if "we can t come to terms. “ Unlock "Back Alley Brawi"(92 (C-14). Party Achievement: "Debt Collection.\'"',
       imageUrl: '/assets/cards/events/base/city/ce-67-b-b.png',
@@ -1445,7 +1445,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-69-b-a.png',
     },
     optionB: {
-      choice: 'Leave the bar before someone recog- nizes you. /',
+      choice: 'Leave the bar before someone recognizes you.',
       outcome:
         "You flee the bar to escape the tune, but it doesn't prove to be that simple. The next day, everyone on the street is humming the tune, They all seems to be looking at you and laughing. It 's a nightmare.\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-69-b-b.png',
@@ -1482,7 +1482,7 @@ export const events: EventEntity[] = [
       "You are walking along the riv- er's edge in the Mixed District late at night when something in votir pack begins to vibrate. The sensation is odd and you quickly fish out the small metal sphere you found out on the road. It shakes uncon- w trollably and then begins pulling your arm toward the river. You walk to the bank, but still the sphere pulls. It is drawn to something in the water.",
     optionA: {
       choice:
-        "Let the sphere go. Option 6: | limp into the river and continue to follow the sphere's pulh ■ /  Option A: -",
+        "Let the sphere go. Option 6: | limp into the river and continue to follow the sphere's pulh  Option A: -",
       outcome:
         "The sphere leaps from your hand, hovers * over the water, and then emits an intense beam of light straight down into the river, illuminating something below. You shrug and jump into the river, following the beam of light down to the bottom. There you ftnd a wooden chest hall buried under the rocks. You bring it back to shore and open it to find a small metal rod covered in strange carvings. When you pick it up, the sphere immediately flics back over to you and attaches itself to the rod's end.\n\nAdd City Event J2 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-71-b-a.png',
@@ -1526,11 +1526,11 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Seek help from the University.',
       outcome:
-        "“Yes, verv interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I II need help pa ving for — / should be able to triangulate that location for you.\n\nLose 5 collective gold. Unlock Crystalline Cave\" 84 (CM2:. Partv Achievement: \"Tremors.'",
+        "“Yes, verv interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold. Unlock Crystalline Cave\" 84 (CM2:. Partv Achievement: \"Tremors.'",
       imageUrl: '/assets/cards/events/base/city/ce-73-b-a.png',
     },
     optionB: {
-      choice: '1 hrow the crystal into the boy. /',
+      choice: 'Throw the crystal into the bay.',
       outcome:
         'Not wanting to waste your time with the problem, you walk to the Jocks anJ throw the crystal into the bay. When you hear reports of harsher weather anJ larger waves hitting the Jocks, you try not to pay them any mind.\n\nLose 1 prosperity.',
       imageUrl: '/assets/cards/events/base/city/ce-73-b-b.png',
@@ -1593,7 +1593,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-76-b-a.png',
     },
     optionB: {
-      choice: 'Decline the suspicious offer and con- tinue your business. /',
+      choice: 'Decline the suspicious offer and continue your business.',
       outcome:
         'Gavin looks flabbergasted as you walk a way. "Who will protect my ships when there is no one to trust? I guess I\'ll just have to keep looking.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-76-b-b.png',
@@ -1614,7 +1614,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-77-b-a.png',
     },
     optionB: {
-      choice: 'Claim you’ve changed your ways and grave robbing is a step too far /',
+      choice: 'Claim you’ve changed your ways and graverobbing is a step too far.',
       outcome:
         '“A downright shame, i say," Nick shakes his head. “I guess I \'ll just have to find a group of mercenaries who actually are interested in make a mountain of money."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-b.png',
@@ -1635,7 +1635,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-78-b-a.png',
     },
     optionB: {
-      choice: 'Demand payment for the job up-front. /',
+      choice: 'Demand payment for the job up-front.',
       outcome:
         '“Look...!, ah, don\'t have a whole lot of capital * right now, but I will give you everything I have once you get back with that artifact.“ You narrow your eyes at him. He coughs nervously and produces a small handful of coins. "All right, fine. Look, here. This is all I can offer you. Now can we get to the part where you go do your job? ”\n\nGain 5 collective gold.\n\nRead outcome A.',
       imageUrl: '/assets/cards/events/base/city/ce-78-b-b.png',
@@ -1677,7 +1677,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-80-b-a.png',
     },
     optionB: {
-      choice: '1 hesc guards are not interested in a Iricndly discourse. Prepare to defend yourself. /',
+      choice: 'The guards are not interested in a friendly discourse. Prepare to defend yourself.',
       outcome:
         'Seeing the situation turning south, you waste no time pulling your weapons and prepare for an attack. The guards are more than happy to oblige. Luckily your foes sustain only some minor injuries in the time it takes for another squad of guards to arrive and break up the scuffle. They let you go on your wayf, but you can see the disdain in all of their eves.\n\nLose 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-80-b-b.png',
@@ -1698,7 +1698,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-81-b-a.png',
     },
     optionB: {
-      choice: 'Claim it wasn’t you and leave quickly. /',
+      choice: 'Claim it wasn’t you and leave quickly.',
       outcome:
         'You brusquely shake your head and wave • your hand away saying the man has the wrong person. His excited face immediately turns to one of disappointment. And audible sigh of dejection emerges from the crowd as you rush away. * “There s no need to be rude about it!* the dockworker yells at your back.\n\nLose 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-81-b-b.png',
@@ -2817,7 +2817,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 54,
     text:
-      "Deep inside a dense forest, you begin to hear the jangling of bells and see a small troupe of performers approaching you through the trees. 'Well, look who it is! * The small voice belongs to a garishly dressed female Qua try I with a lute and a feathered hat. fancy running into you out here. “This actually may be a stroke of luckf the Soothsingcr says. *You see, my compatriots and I seem to be a bit lost. We were beaded toward the Capital when my drummer said he knew a shortcut. Now here wc are in the middle of a forest without an inkling of a clue. / don't suppose you could find it in your heart to escort us back to the main road„ could you?",
+      "Deep inside a dense forest, you begin to hear the jangling of bells and see a small troupe of performers approaching you through the trees. 'Well, look who it is! * The small voice belongs to a garishly dressed female Qua try I with a lute and a feathered hat. fancy running into you out here. “This actually may be a stroke of luckf the Soothsingcr says. *You see, my compatriots and I seem to be a bit lost. We were beaded toward the Capital when my drummer said he knew a shortcut. Now here wc are in the middle of a forest without an inkling of a clue. I don't suppose you could find it in your heart to escort us back to the main road„ could you?",
     optionA: {
       choice: 'Take the time to escort the troupe back out of the forest.',
       outcome:
@@ -3073,7 +3073,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Take cover.',
       outcome:
-        ':\tl! You jump into a ditch and cover your head • just as the Elder Drake glides over the raiding party, breathing a heavy gout of flame into their midst. Those not incinerated scream and flee for their lives. The drake lands in front of you. "Intrepid adventurers! I hope / was able to offer you some aid against your aggressors. It really was my pleasure after all you have done for me. I hope you find some things of value among the corpses. It is my gift to you.\n\nGain 25 gold each.',
+        ':\tl! You jump into a ditch and cover your head • just as the Elder Drake glides over the raiding party, breathing a heavy gout of flame into their midst. Those not incinerated scream and flee for their lives. The drake lands in front of you. "Intrepid adventurers! I hope I was able to offer you some aid against your aggressors. It really was my pleasure after all you have done for me. I hope you find some things of value among the corpses. It is my gift to you.\n\nGain 25 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-66-b-a.png',
     },
     optionB: {
@@ -3100,7 +3100,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Demonstrate your lack of virtue by robbing the merchant.',
       outcome:
-        '"Well I just — / mean, I’d never,.,” the merchant trails ofTincredulously. “To think there are places in the world where such barbarism still exists. It boggles the mind. 7 m going to tell everyone back in the Capital what a horrible, backward shrrggggllg..." Blood bubbles up into his mouth as you slit his throat, making it very difficult for him to continue complaining.\n\nGain 20 gold each.',
+        '"Well I just — I mean, I’d never...” the merchant trails ofTincredulously. “To think there are places in the world where such barbarism still exists. It boggles the mind. 7 m going to tell everyone back in the Capital what a horrible, backward shrrggggllg..." Blood bubbles up into his mouth as you slit his throat, making it very difficult for him to continue complaining.\n\nGain 20 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-67-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-67-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1479,18 +1479,18 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 71,
     text:
-      "You are walking along the riv- er's edge in the Mixed District late at night when something in votir pack begins to vibrate. The sensation is odd and you quickly fish out the small metal sphere you found out on the road. It shakes uncon- w trollably and then begins pulling your arm toward the river. You walk to the bank, but still the sphere pulls. It is drawn to something in the water.",
+      "You are walking along the river's edge in the Mixed District late at night when something in your pack begins to vibrate. The sensation is odd and you quickly fish out the small metal sphere you found out on the road. It shakes uncontrollably and then begins pulling your arm toward the river.\n\nYou walk to the bank, but still the sphere pulls. It is drawn to something in the water.",
     optionA: {
       choice:
-        "Let the sphere go. Option 6: | limp into the river and continue to follow the sphere's pulh  Option A: -",
+        "Let the sphere go.",
       outcome:
-        "The sphere leaps from your hand, hovers * over the water, and then emits an intense beam of light straight down into the river, illuminating something below. You shrug and jump into the river, following the beam of light down to the bottom. There you ftnd a wooden chest hall buried under the rocks. You bring it back to shore and open it to find a small metal rod covered in strange carvings. When you pick it up, the sphere immediately flics back over to you and attaches itself to the rod's end.\n\nAdd City Event J2 to the deck.",
+        "The sphere leaps from your hand, hovers over the water, and then emits an intense beam of light straight down into the river, illuminating something below.\n\nYou shrug and jump into the river, following the beam of light down to the bottom. There you find a wooden chest half buried under the rocks. You bring it back to shore and open it to find a small metal rod covered in strange carvings. When you pick it up, the sphere immediately flies back over to you and attaches itself to the rod's end.\n\nAdd City Event 72 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-71-b-a.png',
     },
     optionB: {
-      choice: '-',
+      choice: 'Jump into the river and continue the sphere\'s pull.',
       outcome:
-        'As soon as you jump into the cold, brackish • waters, (he sphere stops vibrating or pulling. You swim for a while in the direction it was pulling, but eventually you realize you are on a fools errand. You emerge from the river wet and miserable with absolutely nothing (o show for it.',
+        'As soon as you jump into the cold, brackish waters, the sphere stops vibrating or pulling. You swim for a while in the direction it was pulling, but eventually you realize you are on a fool\'s errand. You emerge from the river wet and miserable with absolutely nothing to show for it.\n\nLose 1 {Check}.',
       imageUrl: '/assets/cards/events/base/city/ce-71-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-71-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1616,7 +1616,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Claim you\'ve changed your ways and graverobbing is a step too far.',
       outcome:
-        '“A downright shame, i say," Nick shakes his head. “I guess I \'ll just have to find a group of mercenaries who actually are interested in make a mountain of money."\n\nNo effect.',
+        '"A downright shame, I say," Nick shakes his head. "I guess I\'ll just have to find a group of mercenaries who actually are interested in making a mountain of money."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-77-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2989,13 +2989,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Agree to help the Sun Demons.',
       outcome:
-        'You sigh and agree, warning them that this had better be the last time they ask you for a favor. They give you the location of the Sun Temple and implore you to hurry.\n\nUnlock \"Sun Temple\" 85 (M-3)',
+        'You sigh and agree, warning them that this had better be the last time they ask you for a favor. They give you the location of the Sun Temple and implore you to hurry.\n\nUnlock \"Sun Temple\" 85 (M-3).',
       imageUrl: '/assets/cards/events/base/road/re-62-b-a.png',
     },
     optionB: {
       choice: 'Attack the Sun Demons. It may be the only way to stop them from bothering you.',
       outcome:
-        'Without even speaking, you draw your weapons and attack. The demons are caught off guard, but they bounce back with great ferocity. It is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}/\n\nAll start scenario with 3 damage.',
+        'Without even speaking, you draw your weapons and attack. The demons are caught off guard, but they bounce back with great ferocity. It is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}.\n\nAll start scenario with 3 damage.',
       imageUrl: '/assets/cards/events/base/road/re-62-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-62-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2817,17 +2817,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 54,
     text:
-      "Deep inside a dense forest, you begin to hear the jangling of bells and see a small troupe of performers approaching you through the trees. 'Well, look who it is! * The small voice belongs to a garishly dressed female Qua try I with a lute and a feathered hat. fancy running into you out here. “This actually may be a stroke of luckf the Soothsingcr says. *You see, my compatriots and I seem to be a bit lost. We were beaded toward the Capital when my drummer said he knew a shortcut. Now here wc are in the middle of a forest without an inkling of a clue. I don't suppose you could find it in your heart to escort us back to the main road„ could you?",
+      'Deep inside a dense forest, you begin to hear the jangling of bells and see a small troupe of performers approaching you through the trees.\n\n"Well, look who it is!" The small voice belongs to a garishly dressed female Quatryl with a lute and a feathered hat. "Fancy running into you out here."\n\n"This actually may be a stroke of luck," the Soothsingcr says. "You see, my compatriots and I seem to be a bit lost. We were headed toward the Capital when my drummer said he knew a shortcut. Now here we are in the middle of a forest without an inkling of a clue. I don\'t suppose you could find it in your heart to escort us back to the main road, could you?"',
     optionA: {
       choice: 'Take the time to escort the troupe back out of the forest.',
       outcome:
-        "While escorting the Soothsinger and her troupe out of'the forest, you are able to catch up a bit. She is very happy now as a traveling performer, playing to sold out concerts across the land. When you reach the main road, you say your good-byes and then make the long trek back to where you were going.\n\nGain 1 reputation.\n\nDiscard 2 cards each.",
+        "While escorting the Soothsinger and her troupe out of the forest, you are able to catch up a bit. She is very happy now as a traveling performer, playing to sold out concerts across the land. When you reach the main road, you say your good-byes and then make the long trek back to where you were going.\n\nGain 1 reputation.\n\nDiscard 2 cards each.",
       imageUrl: '/assets/cards/events/base/road/re-54-b-a.png',
     },
     optionB: {
       choice: 'Give detailed directions about the way out and hope that is sufficient.',
       outcome:
-        "W V\tf\tL/tar\triru mejig/ve precise directions on the easiest way out of the forest and back to the main road. The Soothsinger seems impressed and waves good-bye as she heads off.\n\nGain 1 reputation.\n\n : You gauge your bearings and\n\nOTHERWISE: You hem and haw and then give some vague directions back to the road' the Soothsinger looks at you skeptically and heads off.\n\nAdd City Event 69 to the deck.",
+        "{LightningBolts} {TwoMinis} {PointyHead}: You gauge your bearings and then give precise directions on the easiest way out of the forest and back to the main road. The Soothsinger seems impressed and waves good-bye as she heads off.\n\nGain 1 reputation.\n\nOTHERWISE:You hem and haw and then give some vague directions back to the road. The Soothsinger looks at you skeptically and heads off.\n\nAdd City Event 69 to the deck.",
       imageUrl: '/assets/cards/events/base/road/re-54-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-54-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2943,17 +2943,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 60,
     text:
-      'You see smoke on the horizon expecting the worst♦ Sure enough, you approach the scene to ransacked caravan\tburned\\ pillaged, and stroyed by what appears to be Vermlings. You find one survivor among the victims who laments that when the Vermlings came upon them, one of the guards, a large Inox. seemed to throw aside his weapon and simply accept his fate. That s when you find the body of the Brute, torn and bloody among the wreckage. Seeing him this way; the fire gone from his eyes, he appears unnaturally small —fc—frilftll n^—mM—WMM—WWWPMWOMWWW',
+      'You see smoke on the horizon expecting the worst and sigh, expecting the worst. Sure enough, you approach the scene to find a ransacked caravan — burned, pillaged, and destroyed by what appears to be Vermlings.\n\nYou find one survivor among the victims who laments that when the Vermlings came upon them, one of the guards, a large Inox, seemed to throw aside his weapon and simply accept his fate.\n\nThat\'s when you find the body of the Brute, torn and bloody among the wreckage. Seeing him this way, the fire gone from his eyes, he appears unnaturally small.',
     optionA: {
       choice: 'Respectfully bury the dead and mourn their loss.',
       outcome:
-        "Though you didn't take the time to talk with the Brute earlier, now you take the time to bury his corpse and say a few words about his strength of body and character The survivor thanks you for your helpt and you continue on your way once more.\n\nGain 1 reputation.",
+        "Though you didn't take the time to talk with the Brute earlier, now you take the time to bury his corpse and say a few words about his strength of body and character. The survivor thanks you for your help, and you continue on your way once more.\n\nGain 1 reputation.",
       imageUrl: '/assets/cards/events/base/road/re-60-b-a.png',
     },
     optionB: {
       choice: 'Take what you can find and move on.',
       outcome:
-        'Near the corpse of the Brute, you find an axe, presumably the weapon he threw away There\'s really nothing else among the debris, so you wordlessly pick it up and move on.\n\nGain 1 collective "Battle-Axe" (Item 018).',
+        'Near the corpse of the Brute, you find an axe, presumably the weapon he threw away. There\'s really nothing else among the debris, so you wordlessly pick it up and move on.\n\nGain 1 collective "Battle-Axe" (Item 018).',
       imageUrl: '/assets/cards/events/base/road/re-60-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-60-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2712,17 +2712,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 49,
     text:
-      'You are approached on the road by a group of men on horseback. They don t immediately seem menacing, but they are formidable and well organized. One of the men, who wears plate armor and has a sword at his side, addresses you coldly You hail from Gloomhaven, correct? What say you about the politics of the place? Are you for or against military rule in the region? Do you think those loot merchants could do a better job, like they \'re doing with the rest of this doomed land?" Looking closer; you see all the men wear the signet of a tower with an eye at its center',
+      'You are approached on the road by a group of men on horseback. They don\'t immediately seem menacing, but they are formidable and well organized.\n\nOne of the men, who wears plate armor and has a sword at his side, addresses you coldly. "You hail from Gloomhaven, correct? What say you about the politics of the place? Are you for or against military rule in the region? Do you think those fool merchants could do a better job, like they\'re doing with the rest of this doomed land?"\n\nLooking closer, you see all the men wear the signet of a tower with an eye at its center',
     optionA: {
       choice: 'Claim allegiance to the military.',
       outcome:
-        'The armored men seem satisfied with your response and take their hands off their weapons. “Good to find some fellow patriots, ” the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties.\n\nUnlock "Vigil Keep" 80 (K-1).',
+        'The armored men seem satisfied with your response and take their hands off their weapons.\n\n"Good to find some fellow patriots,” the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties.\n\nUnlock "Vigil Keep" 80 (K-1).',
       imageUrl: '/assets/cards/events/base/road/re-49-b-a.png',
     },
     optionB: {
       choice: 'Claim allegiance to the merchant guilds.',
       outcome:
-        'Well then, today \'s your unlucky day, the man in front says. “Because we of the Vigil make it a point to execute any and all commerce sympathizers we can find in this land[ * The men grimly draw swords and advance. After a hard battle, the survivors retreat, leaving you to pick through the corpses. Among the loot you find a map.\n\nUnlock "Vigil Keep" 80 (K-1).\n\nAll start scenario with 4 damage.\n\nGain 5 gold each.',
+        'Well then, today\'s your unlucky day, the man in front says. "Because we of the Vigil make it a point to execute any and all commerce sympathizers we can find in this land."\n\nThe men grimly draw swords and advance. After a hard battle, the survivors retreat, leaving you to pick through the corpses. Among the loot you find a map.\n\nUnlock "Vigil Keep" 80 (K-1).\n\nAll start scenario with 4 damage.\n\nGain 5 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-49-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-49-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1610,7 +1610,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Do the job.',
       outcome:
-        'REPUTATION < -14\n\n"That\'s the money-loving criminals I know and love! Come take a walk with me, and I\'ll explain how we can all get rich."\n\nUnlock "Overgrown Graveyard" 75 (G-12).\n\nParty Achievement: "Grave Job."\n\nOTHERWISE: "Oh, whoops," Nick stammers. "From the back you looked like...uh, never mind. Forget I said anything."\n\nNo effect.',
+        'REPUTATION < -14: "That\'s the money-loving criminals I know and love! Come take a walk with me, and I\'ll explain how we can all get rich."\n\nUnlock "Overgrown Graveyard" 75 (G-12).\n\nParty Achievement: "Grave Job."\n\nOTHERWISE: "Oh, whoops," Nick stammers. "From the back you looked like...uh, never mind. Forget I said anything."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1000,7 +1000,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Begrudgingly pay for the note.',
       outcome:
-        "PAY 5 COLLECTIVE GOLD: You throw the kid a few coins and grab the note. Enclosed with the note is a small medallion engraved with the image of the sun. Apparently the Sunkeeper thinks the object may help you at some point in the future. The note doesn't say exactly how and the thing has no apparent use. You stow it away in your pack.\n\nParty Achievement: \"Sun-Blessed.\".\n\nOTHERWISE: You reach into your pocket to pay the kid, but come up empty-handed. He slinks off in indignation.\n\nNo eflect.",
+        "PAY 5 COLLECTIVE GOLD: You throw the kid a few coins and grab the note. Enclosed with the note is a small medallion engraved with the image of the sun. Apparently the Sunkeeper thinks the object may help you at some point in the future. The note doesn't say exactly how and the thing has no apparent use. You stow it away in your pack.\n\nParty Achievement: \"Sun-Blessed.\".\n\nOTHERWISE: You reach into your pocket to pay the kid, but come up empty-handed. He slinks off in indignation.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-48-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1353,17 +1353,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 65,
     text:
-      "In the middle of the night, you tire wakened by a hard knocking at your door. You answer and it takes you *\tv a second to recognize the man standing on the other side. t hose Oak relics you was look in for, the man J\t* says as he scratches a blister on the side of his lace. Some cut purses tried to sell them to me. I can take you to their place, but we gotta move fast, and I want a cut of the loot. ” You hurriedly agree and make your way to a ramshackle warehouse next to the old docks. ' This is it/' the man says. \"Looks like no one s V* home, though/",
+      "In the middle of the night, you are awakened by a hard knocking at your door. You answer and it takes you a second to recognize the man standing on the other side.\n\n\"Those Oak relics you was lookin' for,\" the man says as he scratches a blister on the side of his face. \"Some cut purses tried to sell them to me. I can take you to their place, but we gotta move fast, and I want a cut of the loot.\"\n\nYou hurriedly agree and make your way to a ramshackle warehouse next to the old docks.\n\n\"This is it,\" the man says. \"Looks like no one's home, though.\"",
     optionA: {
       choice: 'Raid the warehouse and recover the stolen goods.',
       outcome:
-        'You head into the warehouse and search, eventually finding a hidden cache of stolen goods. The thieves, however, are nowhere to be found. You think about waiting for them to return, but it s possible they have already been alerted to your presence. return to the sanctuary, where the priest is pleased to have the artifacts returned, but troubled that the thieves are still out there.\n\nGain 2 reputation.',
+        'You head into the warehouse and search, eventually finding a hidden cache of stolen goods. The thieves, however, are nowhere to be found. You think about waiting for them to return, but it s possible they have already been alerted to your presence. You return to the sanctuary, where the priest is pleased to have the artifacts returned, but troubled that the thieves are still out there.\n\nGain 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-65-b-a.png',
     },
     optionB: {
       choice: 'Wait until the thieves return so you can apprehend them.',
       outcome:
-        'You hide behind some barrels and wait for the thieves to return. It takes the rest of the night, but just as you are about to give up, two men approach the door. It ’s easy enough to get the drop on them, overpower them, and deliver them to the authorities. When you return the stolen artifacts to the sanctuary, the priest is incredibly pleased with your work.\n\nGain 1 prosperity.\n\nGain 2 reputation. «*■**: Gain 1 additional reputation.',
+        'You hide behind some barrels and wait for the thieves to return. It takes the rest of the night, but just as you are about to give up, two men approach the door. It\'s easy enough to get the drop on them, overpower them, and deliver them to the authorities. When you return the stolen artifacts to the sanctuary, the priest is incredibly pleased with your work.\n\nGain 1 prosperity.\n\nGain 2 reputation.\n\n{Saw}: Gain 1 additional reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-65-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-65-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1416,17 +1416,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 68,
     text:
-      "You wake in the middle of the night to the sound of rushing water. In the corner ofyour room, you see a flood gushing out of the head of the Summoner's staff which you had previously picked up in your travels. You jump out of bed and splash through a growing puddle of water to investigate the staff, but you can't make any sense of it. ft seems to be materializing the water out of thin air, possibly channeling it from another plane of existence. You scratch your head, unsure of what to do next.",
+      "You wake in the middle of the night to the sound of rushing water. In the corner of your room, you see a flood gushing out of the head of the Summoner's staff which you had previously picked up in your travels.\n\nYou jump out of bed and splash through a growing puddle of water to investigate the staff, but you can't make any sense of it. It seems to be materializing the water out of thin air, possibly channeling it from another plane of existence. You scratch your head, unsure of what to do next.",
     optionA: {
-      choice: 'Kind some way to get the water to stop gushing.',
+      choice: 'Find some way to get the water to stop gushing.',
       outcome:
-        '; You take a moment to attune yourself to the staff which you feel now has a direct link another plane. The water stops and you are left with an open gate.\n\nUnlock "Plane of Water" 88 (D-l6).\n\nParty Achievement: "Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not be happy.\n\nLose 15 collective gold.\n\nUnlock "Plane of Water" 88 (D-l6).\n\nParty Achievement: "Water Staff."',
+        '{Circles} {Eclipse}: You take a moment to attune yourself to the staff, which you feel now has a direct link another plane. The water stops and you are left with an open gate.\n\nUnlock "Plane of Water" 88 (D-16).\n\nParty Achievement: "Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not be happy.\n\nLose 15 collective gold.\n\nUnlock "Plane of Water" 88 (D-16).\n\nParty Achievement: "Water Staff."',
       imageUrl: '/assets/cards/events/base/city/ce-68-b-a.png',
     },
     optionB: {
-      choice: 'Gel the stall out of your room and throw it into the bay. a l I',
+      choice: 'Get the staff out of your room and throw it into the bay.',
       outcome:
-        "You race out of the inn, trying to minimize the damage caused by the never-ending stream of water. Not knowing what else to do, you head toward the river. Standing on the banks, you shrug and toss the staff into the current. You g uess you 'll never know how the staff ended up where it did or why it suddenly turned into a faucet.\n\nNo effect.",
+        "You race out of the inn, trying to minimize the damage caused by the never-ending stream of water. Not knowing what else to do, you head toward the river. Standing on the banks, you shrug and toss the staff into the current. You guess you'll never know how the staff ended up where it did or why it suddenly turned into a faucet.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-68-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-68-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2901,17 +2901,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 58,
     text:
-      "Despite your best efforts, you find yourself lost in a forest. You thought you were taking a shortcut, but then you got turned around and lost your bearings. And just when you think things couldn t get worse, a wolf suddenly jumps out of the brush in front of you. Oddly; though, it doesn 't appear aggressive. It howls once and then slowly and deliberately begins to walk through the trees in front of you, as if expecting you to follow it.   w. mm",
+      "Despite your best efforts, you find yourself lost in a forest. You thought you were taking a shortcut, but then you got turned around and lost your bearings.\n\nAnd just when you think things couldn't get worse, a wolf suddenly jumps out of the brush in front of you. Oddly; though, it doesn't appear aggressive.\n\nIt howls once and then slowly and deliberately begins to walk through the trees in front of you, as if expecting you to follow it.",
     optionA: {
       choice: 'Follow the wolf.',
       outcome:
-        'Miraculously, following the wolf leads you right to the edge of the forest and back on track to your destination. The wolf howls once more and then bounds off back into the brush. You can t help, but wonder who might have sent that wolf to assist you.\n\nNo effect.',
+        'Miraculously, following the wolf leads you right to the edge of the forest and back on track to your destination. The wolf howls once more and then bounds off back into the brush. You can\'t help, but wonder who might have sent that wolf to assist you.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-58-b-a.png',
     },
     optionB: {
       choice: 'Find your own way through the forest.',
       outcome:
-        'Not willing to trusta wild animal, you ref use to go in the same direction as the wolf and continue down an ill-fated path of your own choosing. It doesn t go well, and by the time you emerge from the dense forest and find your bearings, you are exhausted.\n\nDiscard 3 cards each.',
+        'Not willing to trust a wild animal, you refuse to go in the same direction as the wolf and continue down an ill-fated path of your own choosing. It doesn\'t go well, and by the time you emerge from the dense forest and find your bearings, you are exhausted.\n\nDiscard 3 cards each.',
       imageUrl: '/assets/cards/events/base/road/re-58-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-58-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2691,17 +2691,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 48,
     text:
-      'You see them long before they get close to you radiant balls of light blazing against the horizon. Sun Demons, As they approach, you prepare for an attackr, but the demons have other plans. They menace you with their glowing clawsr, but they would rather have information than kill you. "Where is the one you call a Sunkeeper?" one of them hisses. \' The Valrath neglects her duties, and now we must resolve matters personally * You press for further information, but the demons get angry *These are not your concerns! Tell us where she is or die at our hands!\'',
+      'You see them long before they get close to you — radiant balls of light blazing against the horizon.\n\nSun Demons.\n\nAs they approach, you prepare for an attack, but the demons have other plans. They menace you with their glowing claws, but they would rather have information than kill you.\n\n"Where is the one you call a Sunkeeper?" one of them hisses. "The Valrath neglects her duties, and now we must resolve matters personally."\n\nYou press for further information, but the demons get angry. "These are not your concerns! Tell us where she is or die at our hands!"',
     optionA: {
-      choice: 'Give them whatever information you can on the Sunkeepers whereabouts.',
+      choice: 'Give them whatever information you can on the Sunkeeper\'s whereabouts.',
       outcome:
-        "You're not sure exactly what happened to the Sunkceper after she left the party, but you tell the demons everything you know: They seem satished with your response and even offer a bitter thanks as they fly off to the west.\n\nAdd Road Event 61 to the deck.",
+        "You're not sure exactly what happened to the Sunkeeper after she left the party, but you tell the demons everything you know. They seem satisfied with your response and even offer a bitter thanks as they fly off to the west.\n\nAdd Road Event 61 to the deck.",
       imageUrl: '/assets/cards/events/base/road/re-48-b-a.png',
     },
     optionB: {
       choice: 'Attack the demons. There are a lot of them, but you do not take kindly to threats.',
       outcome:
-        'Without even speaking, you draw your weapons and attack. The demons are caught off guard, but they bounce back with great ferocity, ft is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}.\n\nAll start scenario with 3 damage.',
+        'Without even speaking, you draw your weapons and attack. The demons are caught off guard, but they bounce back with great ferocity. It is a long, brutal battle, and you continue on in your adventure greatly wounded and bloody.\n\nAll start scenario with {Muddle}.\n\nAll start scenario with {Wound}.\n\nAll start scenario with 3 damage.',
       imageUrl: '/assets/cards/events/base/road/re-48-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-48-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2796,17 +2796,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 53,
     text:
-      'fau hear the distinctive sound of metal on metal in the distance and race up a hill in the road to investigate. In front of you, you see a familiar female Inox in heated battle with a group of Gloomhaven guards. Though outnumbered and bloodied\\ youve never seen that stop the Berserker before. With every wound they inflict, she becomes more and more enraged[ cleaving off limbs with the ease of cutting grass< ■v Iff* all',
+      'You hear the distinctive sound of metal on metal in the distance and race up a hill in the road to investigate.\n\nIn front of you, you see a familiar female Inox in heated battle with a group of Gloomhaven guards. Though outnumbered and bloodied, you\'ve never seen that stop the Berserker before. With every wound they inflict, she becomes more and more enraged, cleaving off limbs with the ease of cutting grass.',
     optionA: {
-      choice: 'Help the Berserker fight oH the guards.',
+      choice: 'Help the Berserker fight off the guards.',
       outcome:
-        "iJ > .i i\ty*. M i TO You enter the battle to aid the Berserker, but in her blood rage, she can't distinguish ftriend from foe. She begins hacking away at you with her axe as much as she swings at the guards. You concentrate on taking out the remaining guards, but when you turn back to the Berserker, she seems to have vanished into the nearby forest.\n\nAll start scenario with 3 damage.",
+        "You enter the battle to aid the Berserker, but in her blood rage, she can't distinguish friend from foe. She begins hacking away at you with her axe as much as she swings at the guards. You concentrate on taking out the remaining guards, but when you turn back to the Berserker, she seems to have vanished into the nearby forest.\n\nAll start scenario with 3 damage.",
       imageUrl: '/assets/cards/events/base/road/re-53-b-a.png',
     },
     optionB: {
       choice: "Wait and see what happens. It looks like she's handling herself well enough.",
       outcome:
-        'After a brutal and bloody fight, only the After her blood rage subsides, she collapses from exhaustion. You race to her side and attempt to revive her using a number of powerful potions. She finally awakes and expresses her begrudging gratitude. You ask about the fight, but she just shakes her headl She offers her axe as thanks and then dashes off into the forest. Consume 1 gg item each.\n\nGain 1 collective "Bloody Axe" (Item 117).',
+        'After a brutal and bloody fight, only the Berserker remains standing. After her blood rage subsides, she collapses from exhaustion. You race to her side and attempt to revive her using a number of powerful potions. She finally awakes and expresses her begrudging gratitude. You ask about the fight, but she just shakes her head. She offers her axe as thanks and then dashes off into the forest. Consume {SmallItem} item each.\n\nGain 1 collective "Bloody Axe" (Item 117).',
       imageUrl: '/assets/cards/events/base/road/re-53-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-53-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3027,17 +3027,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 64,
     text:
-      'You move closer, and what you thought was a signpost turns out to be a human skull impaled on a spike. There is something sticking out of the skulls mouth. ^  — - ■ i ii HWW ■ *»-»■ ■* * — —■\t— ■ i ■<————',
+      'You reach a crossroads and deecide to rest for a bit. As you eat some of your rations, something sticking up out of the ground in the distance catches your attention.\n\nYou move closer, and what you thought was a signpost turns out to be a human skull impaled on a spike.\n\nThere is something sticking out of the skulls mouth.',
     optionA: {
       choice: 'Investigate further.',
       outcome:
-        'Against your better judgment; you approach the skull[ which looks suspiciously like the Sin-Ras calling cardl Sure enough, a group of dark-clad warriors appears before you from out of thin air. Wordlessly they draw their long, curved blades and attack* Caught by surprise, you don t fare well in the battle. You do fight them off, but in the end[ you are severely woundedexhausted, and demoralized.\n\nLose 1 {Check} each.\n\nDiscard 4 cards each.\n\nAll start scenario with 4 damage.',
+        'Against your better judgment, you approach the skull, which looks suspiciously like the Sin-Ras calling card. Sure enough, a group of dark-clad warriors appears before you from out of thin air. Wordlessly they draw their long, curved blades and attack. Caught by surprise, you don\'t fare well in the battle. You do fight them off, but in the end, you are severely wounded, exhausted, and demoralized.\n\nLose 1 {Check} each.\n\nDiscard 4 cards each.\n\nAll start scenario with 4 damage.',
       imageUrl: '/assets/cards/events/base/road/re-64-b-a.png',
     },
     optionB: {
       choice: 'Arm yourself and make a defensive retreat from the area.',
       outcome:
-        "Recognizing the pike as a symbol of the Sin-Ra Syndicate, you arm yourself and run from the area. Unfortunately you don't make it far before you see a number of black-clad assassins bearing down on you. You move into a defensive position and prepare for battle. The fight is arduous, but in the end[ the assassins are dead[ and you hope they don t come back.\n\nLose 1 {Check} each.\n\nDiscard 2 cards each.\n\nAll start scenario with 2 damage.",
+        "Recognizing the pike as a symbol of the Sin-Ra Syndicate, you arm yourself and run from the area. Unfortunately you don't make it far before you see a number of black-clad assassins bearing down on you. You move into a defensive position and prepare for battle. The fight is arduous, but in the end, the assassins are dead, and you hope they don t come back.\n\nLose 1 {Check} each.\n\nDiscard 2 cards each.\n\nAll start scenario with 2 damage.",
       imageUrl: '/assets/cards/events/base/road/re-64-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-64-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1342,7 +1342,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Claim you want nothing to do with this and walk away.',
       outcome:
-        "The Sin-Ra Syndicate seems to think you have something to do with this,\" the Nightshroud yells at you as you leave. \"That's all that matters! They'll strike again, and I won't be there to protect you!\" You keep walking.\n\naAdd Road Event 64 to the deck.",
+        "The Sin-Ra Syndicate seems to think you have something to do with this,\" the Nightshroud yells at you as you leave. \"That's all that matters! They'll strike again, and I won't be there to protect you!\" You keep walking.\n\nAdd Road Event 64 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-64-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-64-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -390,7 +390,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Attend the wedding with an expensive gift.',
       outcome:
-        'REPUTATION > 9. PAY 20 COLLECTIVE GOLD: You head to the New Market and find a magnificent vase to bring as a gift. When the father of the bride sees it, he declares it the most wonderful piece he\'s ever encountered. You are the talk of the town.\n\nGain 2 reputation.\n\nREPUTATION < 10, PAY 20 COLLECTIVE GOLD: You bring a very expensive vase as a gift, but you can\'t seem to catch the father of the bride\'s eve to present it at the right time.\n\nNo effect.\n\nOTHERWISE: Read outcome B.',
+        'REPUTATION > 9, PAY 20 COLLECTIVE GOLD: You head to the New Market and find a magnificent vase to bring as a gift. When the father of the bride sees it, he declares it the most wonderful piece he\'s ever encountered. You are the talk of the town.\n\nGain 2 reputation.\n\nREPUTATION < 10, PAY 20 COLLECTIVE GOLD: You bring a very expensive vase as a gift, but you can\'t seem to catch the father of the bride\'s eve to present it at the right time.\n\nNo effect.\n\nOTHERWISE: Read outcome B.',
       imageUrl: '/assets/cards/events/base/city/ce-19-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1332,17 +1332,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 64,
     text:
-      'Late in the evening, you are returning to your rooms when you hear a cry for help coming from a nearby alleyway. Racing into the shadows, you expect to find someone in distress, but instead find a group of men clad in black leather armor eying you maliciously. ‘ We have a message lor your Nightshroud friend, " one of them says, drawing a wicked looking curved blade. Suddenly, the Nightshroud appears among them in a flash of fatal sword strikes. Before the men even have a chance to react, hall of them lie dead on the ground. The other half quickly flee. ‘‘Well, it looks like you\'re into it now, too. Which is good, because I need help taking them down."',
+      'Late in the evening, you are returning to your rooms when you hear a cry for help coming from a nearby alleyway. Racing into the shadows, you expect to find someone in distress, but instead find a group of men clad in black leather armor eying you maliciously.\n\n"We have a message for your Nightshroud friend," one of them says, drawing a wicked looking curved blade. Suddenly, the Nightshroud appears among them in a flash of fatal sword strikes. Before the men even have a chance to react, half of them lie dead on the ground. The other half quickly flee.\n\n"Well, it looks like you\'re into it now, too. Which is good, because I need help taking them down."',
     optionA: {
       choice: 'Stay and listen to what the Nightshroud has to say.',
       outcome:
-        'The Nightshroud kicks one of the corpses. " This is the SinRa Syndicate, a group of assassins trying to gain a foothold in the region. I \'m trying to stop them, and somehow they found out you and I u ere friends. They decided logo after you as retribution. Lucky for you. I\'ve locatcJ their hideout, so were going to sneak in there and end this whole business once and for all. “ Unlock “Syndicate Hideout (89 (C-17). Party Achievement: "Sin-Ra."',
+        'The Nightshroud kicks one of the corpses. " This is the Sin-Ra Syndicate, a group of assassins trying to gain a foothold in the region. I\'m trying to stop them, and somehow they found out you and I were friends. They decided to go after you as retribution. Lucky for you. I\'ve located their hideout, so were going to sneak in there and end this whole business once and for all.\n\nUnlock "Syndicate Hideout 89 (C-17).\n\nParty Achievement: "Sin-Ra."',
       imageUrl: '/assets/cards/events/base/city/ce-64-b-a.png',
     },
     optionB: {
       choice: 'Claim you want nothing to do with this and walk away.',
       outcome:
-        "*The Sin-Ra Syndicate seems to think you have something to do with this/ the Nightshroudyells at you as you leave. That s alt that matters! They II strike again, and I won 't be there to protect you!” You keep walking.\n\naAdd Road Event 64 to the deck.",
+        "The Sin-Ra Syndicate seems to think you have something to do with this,\" the Nightshroud yells at you as you leave. \"That's all that matters! They'll strike again, and I won't be there to protect you!\" You keep walking.\n\naAdd Road Event 64 to the deck.",
       imageUrl: '/assets/cards/events/base/city/ce-64-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-64-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3069,17 +3069,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 66,
     text:
-      'The first sign of the tnox raiding party was a cloud of dust on the horizon. vvja* so large, however, there was nowhere to run, City-dwelling scum!" one of the Inox in front calls out to you as you approach. "We march now to attack your city and wipe it from the face of this landl What do you say to that?” four ifrst thought, as you prepare for a fight. is that they will need a larger army. Before you can strike, though, the sky grows dark. You assume it is a cloud, but then look up to see a giant drake descending on you from above.  >*»■ <■ i i i m !■■■ ■v^vnii(<n Min i',
+      'The first sign of the Inox raiding party was a cloud of dust on the horizon. It was so large, however, there was nowhere to run.\n\n"City-dwelling scum!" one of the Inox in front calls out to you as you approach. "We march now to attack your city and wipe it from the face of this land. What do you say to that?"\n\nYour first thought, as you prepare for a fight, is that they will need a larger army. Before you can strike, though, the sky grows dark. You assume it is a cloud, but then look up to see a giant drake descending on you from above.',
     optionA: {
       choice: 'Take cover.',
       outcome:
-        ':\tl! You jump into a ditch and cover your head • just as the Elder Drake glides over the raiding party, breathing a heavy gout of flame into their midst. Those not incinerated scream and flee for their lives. The drake lands in front of you. "Intrepid adventurers! I hope I was able to offer you some aid against your aggressors. It really was my pleasure after all you have done for me. I hope you find some things of value among the corpses. It is my gift to you.\n\nGain 25 gold each.',
+        'You jump into a ditch and cover your head just as the Elder Drake glides over the raiding party, breathing a heavy gout of flame into their midst. Those not incinerated scream and flee for their lives. The drake lands in front of you.\n\n"Intrepid adventurers! I hope I was able to offer you some aid against your aggressors. It really was my pleasure after all you have done for me. I hope you find some things of value among the corpses. It is my gift to you."\n\nGain 25 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-66-b-a.png',
     },
     optionB: {
       choice: 'Attack the Inox.',
       outcome:
-        'You attack the large group of Inox while they are distracted by giant creature above you. Things suddenly get very hot, however, when the drake begins spitting hre into the melee. The Inox scatter and you are suffering from severe burns when the Elder Drake lands in front of you. "My apologies, I was only trying to help.\n\nGain 25 gold each.\n\nAll start scenario with {Wound}.\n\nAll start scenario with 2 damage.',
+        'You attack the large group of Inox while they are distracted by the giant creature above you. Things suddenly get very hot, however, when the drake begins spitting fire into the melee. The Inox scatter and you are suffering from severe burns when the Elder Drake lands in front of you.\n\n"My apologies, I was only trying to help."\n\nGain 25 gold each.\n\nAll start scenario with {Wound}.\n\nAll start scenario with 2 damage.',
       imageUrl: '/assets/cards/events/base/road/re-66-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-66-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1437,17 +1437,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 69,
     text:
-      'You are rather surprised to walk into the Brown Door one night to see your old friend the Soothsinger playing a song on the corner stage. )bu are even more surprised when you get closer and discover the song is about you. It is a raucous talc about the time she met you in a forest and you gave her terrible directions — just the worst, most backward directions possible. Everyone in the crowd is tearing up with laughter as she eloquently describes your bumbling and ineptitude.',
+      'You are rather surprised to walk into the Brown Door one night to see your old friend the Soothsinger playing a song on the corner stage. You are even more surprised when you get closer and discover the song is about you.\n\nIt is a raucous talc about the time she met you in a forest and you gave her terrible directions — just the worst, most backward directions possible.\n\nEveryone in the crowd is tearing up with laughter as she eloquently describes your bumbling and ineptitude.',
     optionA: {
       choice: 'Embrace the joke and go with it.',
       outcome:
-        'You make your way to the front of the crowd and join in the fun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus, ft s a lit tie embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
+        'You make your way to the front of the crowd and join in the fun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus. It\'s a little embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-69-b-a.png',
     },
     optionB: {
       choice: 'Leave the bar before someone recognizes you.',
       outcome:
-        "You flee the bar to escape the tune, but it doesn't prove to be that simple. The next day, everyone on the street is humming the tune, They all seems to be looking at you and laughing. It 's a nightmare.\n\nLose 1 reputation.",
+        "You flee the bar to escape the tune, but it doesn't prove to be that simple. The next day, everyone on the street is humming the tune. They all seems to be looking at you and laughing. It's a nightmare.\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-69-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-69-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3111,17 +3111,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 68,
     text:
-      'Not too far down the main road f outside of Gloomhaven, you run across a merchant wagon headed into town.\t■ P H I-\tIT Bj B\tI ■ j j [S BJ^B II "Oh no...ah, mercenaries, I see," the merchant stammers as you approach, "Look, ah, I know the reputation of your like around Gloomhaven. Please, just take what you want and move on. I I don t want any trouble."',
+      'Not too far down the main road outside of Gloomhaven, you run across a merchant wagon headed into town.\n\n"Oh no...ah, mercenaries, I see," the merchant stammers as you approach, "Look, ah, I know the reputation of your like around Gloomhaven. Please, just take what you want and move on. I-I don t want any trouble."',
     optionA: {
       choice: 'Take what you want and move on.',
       outcome:
-        "Ihe merchant remains dead silent as you sift through his cart and pull out any valuables. There's not a whole lot in his wares, but the ease in which you are able to take what he has makes it all the sweeter. Once you are finished, you continue on your way and he continues on his.\n\nGain 10 gold each.",
+        "The merchant remains dead silent as you sift through his cart and pull out any valuables. There's not a whole lot in his wares, but the ease in which you are able to take what he has makes it all the sweeter.\n\nOnce you are finished, you continue on your way and he continues on his.\n\nGain 10 gold each.",
       imageUrl: '/assets/cards/events/base/road/re-68-b-a.png',
     },
     optionB: {
       choice: 'Calm the merchant and explain that not all mercenaries are bloodthirsty thieves.',
       outcome:
-        '"Oh, ah, really?" The merchant looks at you incredulously. “Well then, color me embarrassed. I sincerely apologize for my uneducated assumptions. Sometimes you just expect the worst traveling to such backwater locales. “I\'ll be sure to tell everyone I see that not everyone in Gloomhavcn is a criminal, he says as he rides off, tipping his hat to you.\n\nGain 2 reputation.',
+        '"Oh, ah, really?" The merchant looks at you incredulously. "Well then, color me embarrassed. I sincerely apologize for my uneducated assumptions. Sometimes you just expect the worst traveling to such backwater locales.\n\n"I\'ll be sure to tell everyone I see that not everyone in Gloomhaven is a criminal," he says as he rides off, tipping his hat to you.\n\nGain 2 reputation.',
       imageUrl: '/assets/cards/events/base/road/re-68-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-68-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1627,17 +1627,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 78,
     text:
-      'The scene is typical A nervous looking man stands in front of your table at the Sleeping lion. You eye him lazily until he speaks. 7 was, um, told you might be able to help me," he starts. 7 was in the Corpse wood conduct- ing some, uh, business, when my partners and I ivcrc attacked by Vermlings. I barely escaped with my life, but my partners weren\'t so lucky. One of them was carrying something valuable — an artifact we managed to find in our, uh, business. It s very important I get it back. I fol- lowed the Vermlings back to their nest, and I can assure you they have many valuables. I\'ll show you where it is, and you can take whatever you * . *• ■* want. Just bring me back the artifact."',
+      'The scene is typical. A nervous looking man stands in front of your table at the Sleeping lion. You eye him lazily until he speaks.\n\n"I was, um, told you might be able to help me," he starts. "I was in the Corpsewood conducting some, uh, business, when my partners and I were attacked by Vermlings. I barely escaped with my life, but my partners weren\'t so lucky.\n\n"One of them was carrying something valuable — an artifact we managed to find in our, uh, business. It s very important I get it back. I followed the Vermlings back to their nest, and I can assure you they have many valuables. I\'ll show you where it is, and you can take whatever you want. Just bring me back the artifact."',
     optionA: {
       choice: "Accept the man's deal.",
       outcome:
-        'The sweaty man is all too eager to give you the details of where to find this nest. "One you clear the Vermlings and find the artifact, you should be able to locate a large stash of valuables in a pit back behind the main camp. Take whatever you want, just return the artifact to me." )ou smile and nod. After taking the valuables, you should be able to squeeze quite a bit ex- tra out of this fellow as well when you return.\n\nUnlock "Vermling Nest " 94 (F-I2)',
+        'The sweaty man is all too eager to give you the details of where to find this nest.\n\n"Once you clear the Vermlings and find the artifact, you should be able to locate a large stash of valuables in a pit back behind the main camp. Take whatever you want, just return the artifact to me."\n\nYou smile and nod. After taking the valuables, you should be able to squeeze quite a bit extra out of this fellow as well when you return.\n\nUnlock "Vermling Nest" 94 (F-12)',
       imageUrl: '/assets/cards/events/base/city/ce-78-b-a.png',
     },
     optionB: {
       choice: 'Demand payment for the job up-front.',
       outcome:
-        '“Look...!, ah, don\'t have a whole lot of capital * right now, but I will give you everything I have once you get back with that artifact.“ You narrow your eyes at him. He coughs nervously and produces a small handful of coins. "All right, fine. Look, here. This is all I can offer you. Now can we get to the part where you go do your job? ”\n\nGain 5 collective gold.\n\nRead outcome A.',
+        '"Look...!, ah, don\'t have a whole lot of capital right now, but I will give you everything I have once you get back with that artifact."\n\nYou narrow your eyes at him. He coughs nervously and produces a small handful of coins.\n\n"All right, fine. Look, here. This is all I can offer you. Now can we get to the part where you go do your job?"\n\nGain 5 collective gold.\n\nRead outcome A.',
       imageUrl: '/assets/cards/events/base/city/ce-78-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-78-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1248,17 +1248,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 60,
     text:
-      'You are wandering the Ward of Seales in the evening when a crowd of people begins to form outside one of the shops, growing louder and more dense hv the second. /Is you approach, you see a terrified family of Quatrvls through a familiar angry mob. The father pleads with a group of disheveled men with torches. "C heats! A woman next to you screams, \'Burn the store down!" One of the men — clearly not a guard — backhands the father away from the door and pushes his way inside the shop.',
+      'You are wandering the Ward of Scales in the evening when a crowd of people begins to form outside one of the shops, growing louder and more dense by the second.\n\nAs you approach, you see a terrified family of Quatryls through a familiar angry mob. The father pleads with a group of disheveled men with torches.\n\n"Cheats!" A woman next to you screams. "Burn the store down!"\n\nOne of the men — clearly not a guard — backhands the father away from the door and pushes his way inside the shop.',
     optionA: {
       choice: 'Attempt to stop the men from burning down the shop.',
       outcome:
-        ": You push your way to the front of the mob and stop the men as they enter the store. Clearly emotions have gotten the better of these people. Through a calm demeanor, you are able to talk the mob down. A sense of relief washes over the crowd.\n\nGain 1 reputation.\n\nOTHERWISE: You kindly entreat the crowd to back down. It gets a little rough, but it becomes clear the crowd isn't fully into it. After knocking a few heads, the mob disperses.\n\nNo effect.",
+        "{Spellweaver} {PointyHead} {MusicNote}: You push your way to the front of the mob and stop the men as they enter the store. Clearly emotions have gotten the better of these people. Through a calm demeanor, you are able to talk the mob down. A sense of relief washes over the crowd.\n\nGain 1 reputation.\n\nOTHERWISE: You kindly entreat the crowd to back down. It gets a little rough, but it becomes clear the crowd isn't fully into it. After knocking a few heads, the mob disperses.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-60-b-a.png',
     },
     optionB: {
-      choice: 'fake part in the looting and burning of the store.',
+      choice: 'Take part in the looting and burning of the store.',
       outcome:
-        'You watch as one of the men picks up a wooden crate and throws it through the shop window. In a frenzy, the crowd rushes into the storer breaking and looting with mad glee. It s easy enough to move in with the crowd and pick up a few valuable items in the chaos. After you get clear of the crowd, you look back to see billows of smoke rising up from the door and broken window. Not a good day to be a Quatryl.\n\nGain 5 gold each.\n\nLose 1 prosperity.',
+        'You watch as one of the men picks up a wooden crate and throws it through the shop window. In a frenzy, the crowd rushes into the store, breaking and looting with mad glee. It\'s easy enough to move in with the crowd and pick up a few valuable items in the chaos. After you get clear of the crowd, you look back to see billows of smoke rising up from the door and broken window. Not a good day to be a Quatryl.\n\nGain 5 gold each.\n\nLose 1 prosperity.',
       imageUrl: '/assets/cards/events/base/city/ce-60-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-60-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1648,17 +1648,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 79,
     text:
-      'The sun is out and you are en- joying j pleasant stroll across the Silent Bridge until you see two demons attacking a man ahead of you. You get closer and can hear the demons be- rating the man as they swipe at him with their da W5. “You dare spit on us as we walk past? One of them yells. "We will show you the consequences of defying authority!',
+      'The sun is out and you are enjoying a pleasant stroll across the Silent Bridge until you see two demons attacking a man ahead of you.\n\nYou get closer and can hear the demons berating the man as they swipe at him with their claws.\n\n"You dare spit on us as we walk past?" One of them yells. "We will show you the consequences of defying authority!"',
     optionA: {
       choice: "Intervene on the man's behalf.",
       outcome:
-        'There is only one method these demons respect: violence. You run forward and hack at one of the demons\' arms as it comes down to strike at the man. The arm falls limp to the ground and the rest of the demon soon follows. The other demon looks at you with seething rage as you face it with raised weapons. n This grave insult will not go unpunished! This city will feel our wrath!"\n\nLose 1 prosperity.',
+        'There is only one method these demons respect: violence. You run forward and hack at one of the demons\' arms as it comes down to strike at the man. The arm falls limp to the ground and the rest of the demon soon follows.\n\nThe other demon looks at you with seething rage as you face it with raised weapons. "This grave insult will not go unpunished! This city will feel our wrath!"\n\nLose 1 prosperity.',
       imageUrl: '/assets/cards/events/base/city/ce-79-b-a.png',
     },
     optionB: {
       choice: 'Keep walking.',
       outcome:
-        'You continue your stroll, trying to block the • unpleasantness from your mind Unfortu- nately, others around you cannot, and they are reminded of the actions you took that caused this horrible and afl-too-frequent occurrence.\n\nLose 1 reputation.',
+        'You continue your stroll, trying to block the unpleasantness from your mind. Unfortunately, others around you cannot, and they are reminded of the actions you took that caused this horrible and all-too-frequent occurrence.\n\nLose 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-79-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-79-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2880,17 +2880,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 57,
     text:
-      'fay are wandering through an abysmal tog, cursing the very tact you woke up this morningYou cant see two feet in front of your face and everything is just so cot and damp. Walking down what you think is the road, you nearfy bump into an elderly Savvas. ”Ah, how fortuitous is such a meeting," the Savvas says. *You look like the ones whom my protege worked with for some time. Normally I would not give the lesser races a second glance, but the master of elements must have seen something in you." It stretches its joints and looks around. 7 lmmr you must be having a rough time with this weather I could offer you something that may help.*',
+      'You are wandering through an abysmal fog, cursing the very fact you woke up this morning. You can\'t see two feet in front of your face and everything is just so cold and damp.\n\nWalking down what you think is the road, you nearly bump into an elderly Savvas.\n\n"Ah, how fortuitous is such a meeting," the Savvas says. "You look like the ones whom my protégé worked with for some time. Normally I would not give the lesser races a second glance, but the master of elements must have seen something in you."\n\nIt stretches its joints and looks around. "Hmm, you must be having a rough time with this weather I could offer you something that may help."',
     optionA: {
       choice: 'Accept the gift of the Savvas.',
       outcome:
-        'The Savvas concentrates and lays its hand on you. You suddenly Feel very warm and all the fog within ten feet of you dissipates. “There you go. That should make things easier. The effect should last for at least as long as the fog does. Have a pleasant day!"\n\nNo effect.',
+        'The Savvas concentrates and lays its hand on you. You suddenly feel very warm and all the fog within ten feet of you dissipates.\n\n"There you go. That should make things easier. The effect should last for at least as long as the fog does. Have a pleasant day!"\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-57-b-a.png',
     },
     optionB: {
-      choice: 'Downplay your struggle and politely decline the Savvass offer.',
+      choice: 'Downplay your struggle and politely decline the Savvas\'s offer.',
       outcome:
-        "“Aht l seet ° the Savvas says. “You'd rather grow from an experience than take the easy way out. A noble path.* The Savvas slaps you on the back. 'Well, get to it, then! It s just fog after all. You'll survive.\"\n\nDiscard 2 cards each.\n\nAdd Road Event 63 to the deck.",
+        'Ah, 1 see," the Savvas says. "You\'d rather grow from an experience than take the easy way out. A noble path."\n\nThe Savvas slaps you on the back. "Well, get to it, then! It\'s just fog after all. You\'ll survive."\n\nDiscard 2 cards each.\n\nAdd Road Event 63 to the deck.',
       imageUrl: '/assets/cards/events/base/road/re-57-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-57-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -159,7 +159,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'The map docs look valuable. Decide to bargain for it.',
       outcome:
-        'PAY 20 (reputation < 10) or 15 (reputation > 9) COLLECTIVE GOLD: After some amount of haggling back and forth, you settle on a price and pay for the map. You recognize some of the landmarks and should be able to find this place of "untold treasure "by hiring a ship.\n\nUnlock "Sunken Vessel" 93 (N-17)\n\nParty Achievement: "A Map to Treasure."\n\nOTHERWISE: Despite your valiant efforts, you cannot get the merchant to lower his price to something you can afford.\n\nNo effect.',
+        'PAY 20 (reputation < 10) or 15 (reputation > 9) COLLECTIVE GOLD: After some amount of haggling back and forth, you settle on a price and pay for the map. You recognize some of the landmarks and should be able to find this place of "untold treasure "by hiring a ship.\n\nUnlock "Sunken Vessel" 93 (N-17).\n\nParty Achievement: "A Map to Treasure."\n\nOTHERWISE: Despite your valiant efforts, you cannot get the merchant to lower his price to something you can afford.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-08-b-a.png',
     },
     optionB: {
@@ -642,7 +642,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Leave with the woman to help her find her missing daughter.',
       outcome:
-        'Once outside, the woman hands you a large pouch of gold. "My father saw the whole thing, but then he went mad and ran toward the Silent Bridge. Please find him and he\'ll help you find my daughter!"\n\nGain 20 collective gold.\n\nUnlock "Shadows Within" 83 (C-15)\n\nParty Achievement: "Bad Business."',
+        'Once outside, the woman hands you a large pouch of gold. "My father saw the whole thing, but then he went mad and ran toward the Silent Bridge. Please find him and he\'ll help you find my daughter!"\n\nGain 20 collective gold.\n\nUnlock "Shadows Within" 83 (C-15).\n\nParty Achievement: "Bad Business."',
       imageUrl: '/assets/cards/events/base/city/ce-31-b-a.png',
     },
     optionB: {
@@ -979,7 +979,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Intervene with the guards and find out what is going on.',
       outcome:
-        "The guards look incredibly perturbed when you step in front of them and ask that they leave the Mindthief to you. After some effort, they begrudgingly hand her over. The Mindthief thanks you, explaining that her colony in the sewers is being poisoned, and the poison is quickly migrating to the city's water supply. She says she’s tracked the source to a small cove along the Hook Coast.\n\nLose 1 reputation. Unlock Corrupted Cove 87 (I-9). Party Achievement: \"The Poison's Source.\"",
+        "The guards look incredibly perturbed when you step in front of them and ask that they leave the Mindthief to you. After some effort, they begrudgingly hand her over. The Mindthief thanks you, explaining that her colony in the sewers is being poisoned, and the poison is quickly migrating to the city's water supply. She says she’s tracked the source to a small cove along the Hook Coast.\n\nLose 1 reputation.\n\nUnlock \"Corrupted Cove\" 87 (I-9).\n\nParty Achievement: \"The Poison's Source.\"",
       imageUrl: '/assets/cards/events/base/city/ce-47-b-a.png',
     },
     optionB: {
@@ -1405,7 +1405,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Refuse to pay. You won\'t be strongarmed by anyone.',
       outcome:
-        'You laugh and wave your hand dismissively. I here \'s no way you will be paying such a large amount of money to these thugs. Unfortunately, the Inox is not amused. m " Then your payment will he blood! she says "Meet us in the back alley, and ivc \'ll see if "we can t come to terms. “ Unlock "Back Alley Brawi"(92 (C-14). Party Achievement: "Debt Collection.\'"',
+        'You laugh and wave your hand dismissively. I here \'s no way you will be paying such a large amount of money to these thugs. Unfortunately, the Inox is not amused. m " Then your payment will he blood! she says "Meet us in the back alley, and ivc \'ll see if "we can t come to terms.\n\nUnlock "Back Alley Brawi" 92 (C-14).\n\nParty Achievement: "Debt Collection."',
       imageUrl: '/assets/cards/events/base/city/ce-67-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-67-f.png',
@@ -1420,7 +1420,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Kind some way to get the water to stop gushing.',
       outcome:
-        '; You take a moment to attune yourself to the staff which you feel now has a direct link another plane. The water stops and you are left with an openga Unlock Plane of Water "(88)(D-l6}. Party Achievement: “Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not be happy.\n\nLose 15 collective gold. Unlock "Plane of Water (8&(D-l6). Party Achievement: \'Water Staff."',
+        '; You take a moment to attune yourself to the staff which you feel now has a direct link another plane. The water stops and you are left with an open gate.\n\nUnlock "Plane of Water" 88 (D-l6).\n\nParty Achievement: "Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not be happy.\n\nLose 15 collective gold.\n\nUnlock "Plane of Water" 88 (D-l6).\n\nParty Achievement: "Water Staff."',
       imageUrl: '/assets/cards/events/base/city/ce-68-b-a.png',
     },
     optionB: {
@@ -1505,7 +1505,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Follow the smelly old bandit.',
       outcome:
-        'Your curiosity gets the better of your judg- • ment. You need to know the purpose of the device you found, so you follow Fish into«) derelict shock where he pulls out a map of the area ond lays it on o table. Fish directs you to pull out your rod ond both you and he hold your respective rods over the toble. 4 specific location on the mop glows brightly ond Fish loughs. ‘See? I toldya. didn \'t I? Meet me there with your rod and we ll get rich!" Unlock Lost Temple (79)(K-I2). Party Achievement: "Fish\'s Aid.”',
+        'Your curiosity gets the better of your judg- • ment. You need to know the purpose of the device you found, so you follow Fish into«) derelict shock where he pulls out a map of the area ond lays it on o table. Fish directs you to pull out your rod ond both you and he hold your respective rods over the toble. 4 specific location on the mop glows brightly ond Fish loughs. ‘See? I toldya. didn \'t I? Meet me there with your rod and we ll get rich!\n\nUnlock "Lost Temple" 79 (K-I2).\n\nParty Achievement: "Fish\'s Aid."',
       imageUrl: '/assets/cards/events/base/city/ce-72-b-a.png',
     },
     optionB: {
@@ -1526,7 +1526,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Seek help from the University.',
       outcome:
-        "“Yes, very interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold. Unlock Crystalline Cave\" 84 (CM2:. Partv Achievement: \"Tremors.'",
+        "“Yes, very interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold.\n\nUnlock \"Crystalline Cave\" 84 (D-12).\n\nParty Achievement: \"Tremors.\"",
       imageUrl: '/assets/cards/events/base/city/ce-73-b-a.png',
     },
     optionB: {
@@ -1589,7 +1589,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Accept the drink.',
       outcome:
-        'REPUTATION > 14: “Excellent!Someone has been attacking my ships at sea and I need to get to the bottom of\'it. Come, I’ll tell you the details." Unlock Merchant Ship (74)0 ’4). Party Achievement: “High Sea Escort."\n\nOTHERWISE: "Oh. whoops."Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\' No elfect.',
+        'REPUTATION > 14: “Excellent!Someone has been attacking my ships at sea and I need to get to the bottom of\'it. Come, I’ll tell you the details.\n\nUnlock "Merchant Ship" 74 (I-14).\n\nParty Achievement: "High Sea Escort."\n\nOTHERWISE: "Oh. whoops."Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-76-b-a.png',
     },
     optionB: {
@@ -1631,7 +1631,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: "Accept the man's deal.",
       outcome:
-        'BThe sweaty man is ail too eager to give you ■ the details of where to find this nest. "One you clear the Vermlings and find the artifact, you should be able to locate a large stash of valuables in a pit back behind the main camp. Take whatever you want, just return the artifact to me." )ou smile and nod. After taking the valuables, you should be able to squeeze quite a bit ex- tra out of this fellow as well when you return. Unlock "Vermling Nest "(94)(F-I2)',
+        'The sweaty man is all too eager to give you the details of where to find this nest. "One you clear the Vermlings and find the artifact, you should be able to locate a large stash of valuables in a pit back behind the main camp. Take whatever you want, just return the artifact to me." )ou smile and nod. After taking the valuables, you should be able to squeeze quite a bit ex- tra out of this fellow as well when you return.\n\nUnlock "Vermling Nest " 94 (F-I2)',
       imageUrl: '/assets/cards/events/base/city/ce-78-b-a.png',
     },
     optionB: {
@@ -2716,13 +2716,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Claim allegiance to the military.',
       outcome:
-        'The armored men seem satisfied with your response and take their hands off their weapons. “Good to find some fellow patriots, ” the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties. ” Unlock "Vigil Keep*(8(}) (K-l).',
+        'The armored men seem satisfied with your response and take their hands off their weapons. “Good to find some fellow patriots, ” the one in front says with a disturbing smile. "You know, we have a stronghold not far from here up in the mountains. Feel free to visit there if you ever get serious about your loyalties.\n\nUnlock "Vigil Keep" 80 (K-1).',
       imageUrl: '/assets/cards/events/base/road/re-49-b-a.png',
     },
     optionB: {
       choice: 'Claim allegiance to the merchant guilds.',
       outcome:
-        'Well then, today \'s your unlucky day, the man in front says. “Because we of the Vigil make it a point to execute any and all commerce sympathizers we can find in this land[ * The men grimly draw swords and advance. After a hard battle, the survivors retreat, leaving you to pick through the corpses. Among the loot you find a map. Unlock "Vigil Keep\\8(j)(K-l).\n\nAll start scenario with 4 damage.\n\nGain 5 gold each.',
+        'Well then, today \'s your unlucky day, the man in front says. “Because we of the Vigil make it a point to execute any and all commerce sympathizers we can find in this land[ * The men grimly draw swords and advance. After a hard battle, the survivors retreat, leaving you to pick through the corpses. Among the loot you find a map.\n\nUnlock "Vigil Keep" 80 (K-1).\n\nAll start scenario with 4 damage.\n\nGain 5 gold each.',
       imageUrl: '/assets/cards/events/base/road/re-49-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-49-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1585,17 +1585,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 76,
     text:
-      'You are walking through the new docks when a well-dressed merchant Hags you down. • • Oh, my, what a fortuitous encounter, " he whispers as you approach, "May I buy you a drink? I have a very sensitive job for you, and I \'d like to avoid the prying eyes around us. The merchant, an iron dealer named Gavin, makes a gesture toward a large group of dock workers. “I can\'t trust anyone. Well, anyone ex- cept you of course',
+      'You are walking through the new docks when a well-dressed merchant flags you down.\n\n"Oh, my, what a fortuitous encounter," he whispers as you approach. "May I buy you a drink? I have a very sensitive job for you, and I \'d like to avoid the prying eyes around us."\n\nThe merchant, an iron dealer named Gavin, makes a gesture toward a large group of dock workers. "I can\'t trust anyone. Well, anyone except you of course."',
     optionA: {
       choice: 'Accept the drink.',
       outcome:
-        'REPUTATION > 14: “Excellent!Someone has been attacking my ships at sea and I need to get to the bottom of\'it. Come, I’ll tell you the details.\n\nUnlock "Merchant Ship" 74 (I-14).\n\nParty Achievement: "High Sea Escort."\n\nOTHERWISE: "Oh. whoops."Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\n\nNo effect.',
+        'REPUTATION > 14: "Excellent! Someone has been attacking my ships at sea and I need to get to the bottom of it. Come, I’ll tell you the details."\n\nUnlock "Merchant Ship" 74 (I-14).\n\nParty Achievement: "High Sea Escort."\n\nOTHERWISE: "Oh. whoops." Gavin stammers. "From far away, you looked like someone else. Just ignore what I said.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-76-b-a.png',
     },
     optionB: {
       choice: 'Decline the suspicious offer and continue your business.',
       outcome:
-        'Gavin looks flabbergasted as you walk a way. "Who will protect my ships when there is no one to trust? I guess I\'ll just have to keep looking.\n\nNo effect.',
+        'Gavin looks flabbergasted as you walk away. "Who will protect my ships when there is no one to trust? I guess I\'ll just have to keep looking."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-76-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-76-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -3006,17 +3006,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 63,
     text:
-      'As you walk through some foothills, the ground suddenly shakes violently beneath you. Two massive demons built of earth and stone rise up in front of you, Today we shall feast on your flesh, foolish travelers!m fust as the demons take a step toward you, a massive ball of fire streaks through the air from behind and connects squarely with one of the demons, which erupts into a pillar of flame. Then lightning streaks toward the other, destroying one of its arms. Looking around, you see the old Savvas you met earlier, who continues to throw out powerful attacks until the demons are forced to retreat, “Well, fancy meeting you again!*',
+      'As you walk through some foothills, the ground suddenly shakes violently beneath you. Two massive demons built of earth and stone rise up in front of you.\n\n"Today we shall feast on your flesh, foolish travelers!"\n\nJust as the demons take a step toward you, a massive ball of fire streaks through the air from behind and connects squarely with one of the demons, which erupts into a pillar of flame. Then lightning streaks toward the other, destroying one of its arms.\n\nLooking around, you see the old Savvas you met earlier, who continues to throw out powerful attacks until the demons are forced to retreat.\n\n"Well, fancy meeting you again!"',
     optionA: {
       choice: 'Thank the Savvas for his timely assistance.',
       outcome:
-        '1Alorc and more demons around these parts these days. Stopping them from attacking travelers is becoming a time-intensive job, but at least it s fun." The Savvas smiles at you and then turns to leave. "Have a pleasant day!"\n\nNo effect.',
+        '"More and more demons around these parts these days. Stopping them from attacking travelers is becoming a time-intensive job, but at least it\'s fun."\n\nThe Savvas smiles at you and then turns to leave. "Have a pleasant day!"\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-63-b-a.png',
     },
     optionB: {
       choice: 'Admonish the Savvas, claiming you could have handled the demons without his help.',
       outcome:
-        'The Savvas adopts a look of serious contemplation. “You are right, of course. I presumed to think that a lesser race would need my help, but l Forgot your dedication to growth and learning. I have made a grave mistake and must now beg your forgiveness. It holds out a small trinket toward you. Please, accept this with my apologies."\n\nGain 1 collective "Sun Earring" (Item 049).',
+        'The Savvas adopts a look of serious contemplation. "You are right, of course. I presumed to think that a lesser race would need my help, but I forgot your dedication to growth and learning. I have made a grave mistake and must now beg your forgiveness."\n\nIt holds out a small trinket toward you. "Please, accept this with my apologies."\n\nGain 1 collective "Sun Earring" (Item 049).',
       imageUrl: '/assets/cards/events/base/road/re-63-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-63-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -138,7 +138,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Help the captain load his ship.',
       outcome:
-        'What was advertised as a few minutes turns out to be an hour or two as you lug large crates full of some foul-smelling liquid from a nearby warehouse into the hold of the ship, At least the captain is relieved that he\'ll be able to set sail on time, though. He gratefully pays you, but you can\'t help, but think that such menial labor might be beneath you.\n\nGain 5 gold each.\n\nReputation > 9: lose 1 reputation.\n\nReputation < -4: Gain 1 reputation.',
+        'What was advertised as a few minutes turns out to be an hour or two as you lug large crates full of some foul-smelling liquid from a nearby warehouse into the hold of the ship, At least the captain is relieved that he\'ll be able to set sail on time, though. He gratefully pays you, but you can\'t help, but think that such menial labor might be beneath you.\n\nGain 5 gold each.\n\nReputation > 9: Lose 1 reputation.\n\nReputation < -4: Gain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-07-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1501,17 +1501,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 72,
     text:
-      "The metal sphere and rod — you 've had them in your possession for a while non and occasionally pull them out to mull o\\er the can ings. Youve brought it to the University, but they can't make any sense of it either you are fiddling with the device in the Sleeping Lion when you are tapped on the shoulder. )ou turn to see a wicked grin on the dirt\\ face of a old bandit. They call me Fish and that there is a Lev, friend a ke\\ of the ancient sort. . * ^ Before you can ask, Fish pulls out a similar black sphere atop a metal rod. \"They're twins, ain't they, and Fish knows just what they open. \\ tomb of treasure, friend Come, come, Fish will show you the * w\t*r *1",
+      "The metal sphere and rod — you've had them in your possession for a while now and occasionally pull them out to mull over the carvings. You've brought it to the University, but they can't make any sense of it either.\n\nYou are fiddling with the device in the Sleeping Lion when you are tapped on the shoulder. You turn to see a wicked grin on the dirty face of an old bandit. \"They call me Fish, and that there is a key, friend — a key of the ancient sort.\"\n\nBefore you can ask, Fish pulls out a similar black sphere atop a metal rod. \"They're twins, ain't they, and Fish knows just what they open. A tomb of treasure, friend. Come, come, Fish will show you the way.\"",
     optionA: {
       choice: 'Follow the smelly old bandit.',
       outcome:
-        'Your curiosity gets the better of your judg- • ment. You need to know the purpose of the device you found, so you follow Fish into«) derelict shock where he pulls out a map of the area ond lays it on o table. Fish directs you to pull out your rod ond both you and he hold your respective rods over the toble. 4 specific location on the mop glows brightly ond Fish loughs. ‘See? I toldya. didn \'t I? Meet me there with your rod and we ll get rich!\n\nUnlock "Lost Temple" 79 (K-I2).\n\nParty Achievement: "Fish\'s Aid."',
+        'Your curiosity gets the better of your judgment. You need to know the purpose of the device you found, so you follow Fish into a derelict shack where he pulls out a map of the area and lays it on a table. Fish directs you to pull out your rod and both you and he hold your respective rods over the table.\n\nA specific location on the map glows brightly ond Fish laughs. "See? I told ya, didn\'t I? Meet me there with your rod and we\'ll get rich!"\n\nUnlock "Lost Temple" 79 (K-12).\n\nParty Achievement: "Fish\'s Aid."',
       imageUrl: '/assets/cards/events/base/city/ce-72-b-a.png',
     },
     optionB: {
-      choice: 'Refuse to go with the man. This whole situation seems fishy.',
+      choice: 'Refuse to go with the man. This whole situation seems...fishy.',
       outcome:
-        "This suspicious old man must have seen you in here before with the rod and fashioned some elaborate con to swindle you out of something. You won i be so easily fooled. There's no he knows what the rod does when no one else in town does. Vbi/ push him away and go back to your drink.\n\nNo effect.",
+        "This suspicious old man must have seen you in here before with the rod and fashioned some elaborate con to swindle you out of something. You won't be so easily fooled. There's no way he knows what the rod does when no one else in town does. You push him away and go back to your drink.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-72-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-72-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1395,17 +1395,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 67,
     text:
-      "You are trying to enjoy a relaxing drink at the Sleeping Lion when a number of large men and Inox burst into the tavern and approach your table. 'So, you must be that little creeps collateral/ one of the Inox says. Were here to collect/' When you stare at her in silencef she tries again, Little grey bearded man. Wore symbols of the Great Oak. He said you lot would pay oil his debt if he couldn ft. * She pats an axe at her side. ''Now, seeing as how he apparently skipped town, you can pay us, or things are gonna get ugly.H",
+      "You are trying to enjoy a relaxing drink at the Sleeping Lion when a number of large men and Inox burst into the tavern and approach your table.\n\n\"So, you must be that little creep's collateral,\" one of the Inox says.\"We're here to collect.\"\n\nWhen you stare at her in silence, she tries again. \"Little grey-bearded man. Wore symbols of the Great Oak. He said you lot would pay off his debt if he couldn't.\"\n\nShe pats an axe at her side. \"Now, seeing as how he apparently skipped town, you can pay us, or things are gonna get ugly.\"",
     optionA: {
       choice: 'Pay off the thugs.',
       outcome:
-        "PAY 60 COLLECTIVE GOLD: You sigh • and hand over the Sawbones' debt, plus interest. Though it feels terrible, the thugs are satisfied and walk out the same way they came in. At least it is over now.\n\nNo effect.\n\nOTHERWISE: Seeing as how you don't have enough money, you decide pursue other options.\n\nRead outcome B.",
+        "PAY 60 COLLECTIVE GOLD: You sigh and hand over the Sawbones' debt, plus interest. Though it feels terrible, the thugs are satisfied and walk out the same way they came in. At least it is over now.\n\nNo effect.\n\nOTHERWISE: Seeing as how you don't have enough money, you decide to pursue other options.\n\nRead outcome B.",
       imageUrl: '/assets/cards/events/base/city/ce-67-b-a.png',
     },
     optionB: {
       choice: 'Refuse to pay. You won\'t be strongarmed by anyone.',
       outcome:
-        'You laugh and wave your hand dismissively. I here \'s no way you will be paying such a large amount of money to these thugs. Unfortunately, the Inox is not amused. m " Then your payment will he blood! she says "Meet us in the back alley, and ivc \'ll see if "we can t come to terms.\n\nUnlock "Back Alley Brawi" 92 (C-14).\n\nParty Achievement: "Debt Collection."',
+        'You laugh and wave your hand dismissively. There\'s no way you will be paying such a large amount of money to these thugs. Unfortunately, the Inox is not amused.\n\n"Then your payment will be blood!" she says. "Meet us in the back alley, and we\'ll see if we can\'t come to terms.\n\nUnlock "Back Alley Brawl" 92 (C-14).\n\nParty Achievement: "Debt Collection."',
       imageUrl: '/assets/cards/events/base/city/ce-67-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-67-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1336,7 +1336,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Stay and listen to what the Nightshroud has to say.',
       outcome:
-        'The Nightshroud kicks one of the corpses. " This is the Sin-Ra Syndicate, a group of assassins trying to gain a foothold in the region. I\'m trying to stop them, and somehow they found out you and I were friends. They decided to go after you as retribution. Lucky for you. I\'ve located their hideout, so were going to sneak in there and end this whole business once and for all.\n\nUnlock "Syndicate Hideout" 89 (C-17).\n\nParty Achievement: "Sin-Ra."',
+        'The Nightshroud kicks one of the corpses. "This is the Sin-Ra Syndicate, a group of assassins trying to gain a foothold in the region. I\'m trying to stop them, and somehow they found out you and I were friends. They decided to go after you as retribution. Lucky for you. I\'ve located their hideout, so were going to sneak in there and end this whole business once and for all."\n\nUnlock "Syndicate Hideout" 89 (C-17).\n\nParty Achievement: "Sin-Ra."',
       imageUrl: '/assets/cards/events/base/city/ce-64-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1690,17 +1690,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 81,
     text:
-      'Hey aren t you the mercenar- ies who stopped that weird tornado f rom destroying the city?” You turn to see a dirt* dock worker point- ing at you w ith wonder in his eves. What was that all about anyway? \\ tore people stop and stare at you. This has become and unfortunately common occurrence * since the Gloom was destroyed. )ou have be- come something of a minor celebrity in Gloom- haven.',
+      '"Hey aren\'t you the mercenaries who stopped that weird tornado from destroying the city?"\n\nYou turn to see a dirty dock worker pointing at you with wonder in his eyes. What was that all about anyway?"\n\nMore people stop and stare at you. This has become and unfortunately common occurrence since the Gloom was destroyed. You have become something of a minor celebrity in Gloomhaven.',
     optionA: {
       choice: 'Take the time to relate the story of what happened.',
       outcome:
-        'You smile and nod[ explaining how an ancient force attempted to destroy the city, but it was banished to another plane. Everyone around you stands enraptured by your story and cheers and claps at its conclusion. After a few additional questions, you are finally able extricate yourself from the crowd and continue your business.\n\nGain 2 reputation.',
+        'You smile and nod explaining how an ancient force attempted to destroy the city, but it was banished to another plane. Everyone around you stands enraptured by your story and cheers and claps at its conclusion. After a few additional questions, you are finally able extricate yourself from the crowd and continue your business.\n\nGain 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-81-b-a.png',
     },
     optionB: {
-      choice: 'Claim it wasn’t you and leave quickly.',
+      choice: 'Claim it wasn\'t you and leave quickly.',
       outcome:
-        'You brusquely shake your head and wave • your hand away saying the man has the wrong person. His excited face immediately turns to one of disappointment. And audible sigh of dejection emerges from the crowd as you rush away. * “There s no need to be rude about it!* the dockworker yells at your back.\n\nLose 2 reputation.',
+        'You brusquely shake your head and wave your hand away saying the man has the wrong person. His excited face immediately turns to one of disappointment. And audible sigh of dejection emerges from the crowd as you rush away.\n\n"There\'s no need to be rude about it!" the dockworker yells at your back.\n\nLose 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-81-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-81-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2775,17 +2775,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 52,
     text:
-      'You smell the corpses before you see them, A group of five or so, spread across the road, flies buzzing around in a frenzy. 4s you get closer, you see the wretched, deformed looks on their faces and the boils covering their skin, You also see their crude armor and weapons likely a group of cutthroats. What is truly odd’ though, is that their weapons are out of their sheaths in the first place. It appears they went* engaged in battle when they suddenly succumbed to some horrible disease. You can think of at least one way that could have happened. Fine handiwork from the Plagueherald, «w WV',
+      'You smell the corpses before you see them. A group of five or so, spread across the road, flies buzzing around in a frenzy.\n\nAs you get closer, you see the wretched, deformed looks on their faces and the boils covering their skin. You also see their crude armor and weapons — likely a group of cutthroats.\n\nWhat is truly odd though, is that their weapons are out of their sheaths in the first place. It appears they were engaged in battle when they suddenly succumbed to some horrible disease.\n\nYou can think of at least one way that could have happened. Fine handiwork from the Plagueherald.',
     optionA: {
       choice: 'Leave the corpses alone.',
       outcome:
-        'Knowing better Own to get too close to the machinations of the Plaguehcrald, you keep a wide berth between you and the corpses and continue down the road.\n\nNo effect.',
+        'Knowing better than to get too close to the machinations of the Plaguehcrald, you keep a wide berth between you and the corpses and continue down the road.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-52-b-a.png',
     },
     optionB: {
       choice: 'Inspect the corpses for valuables.',
       outcome:
-        'You rifle through the corpses, grabbing stray • coins and valuables as you go. You make off with a good haul, but you start feeling sick as soon as you re done.\n\nAll start scenario with {Poison}.\n\nAll start scenario with {Curse}.\n\nGain 10 collective gold.',
+        'You rifle through the corpses, grabbing stray coins and valuables as you go. You make off with a good haul, but you start feeling sick as soon as you re done.\n\nAll start scenario with {Poison}.\n\nAll start scenario with {Curse}.\n\nGain 10 collective gold.',
       imageUrl: '/assets/cards/events/base/road/re-52-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-52-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1458,17 +1458,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 70,
     text:
-      'You are wandering the Sink- ing Market looking for possible work when you are approached by a dirty-looking bov with a scar on his check. You greet him warmly. He has given you leads on a number of mercenary jobs and you re- cently helped him avoid a jail ceil. "I need some help, and I really don\'t know who else to turn to, " he begins. \'All of us here in (he Sinking Market are in a had way; Our houses are collapsing, our water is foul\\ and we den t even have enough money for food[ "We are dying here. and the city is doing nothing to help us. You have friends in high places, right? Please, there \'s gotta be someone you can talk to.',
+      'You are wandering the Sinking Market looking for possible work when you are approached by a dirty-looking boy with a scar on his cheek.\n\nYou greet him warmly. He has given you leads on a number of mercenary jobs and you recently helped him avoid a jail cell.\n\n"I need some help, and I really don\'t know who else to turn to," he begins. "All of us here in the Sinking Market are in a bad way. Our houses are collapsing, our water is foul, and we don\'t even have enough money for food.\n\n"We are dying here, and the city is doing nothing to help us. You have friends in high places, right? Please, there\'s gotta be someone you can talk to.',
     optionA: {
-      choice: 'Talk to some merchants about revital- izing the area.',
+      choice: 'Talk to some merchants about revitalizing the area.',
       outcome:
-        "REPUTATION > 9: You head to the Coin # District and meet with a member of the merchant s guild you've had dealings with before. He looks at you skeptically, but says he will see what he can do about making the area more livable.\n\nGain 1 prosperity.\n\nOTHERWISE: Every merchant you try to talk to about the issue laughs you out of the room. Why help others when there is no prof- it in it for them?\n\nLose 1 reputation.",
+        "REPUTATION > 9: You head to the Coin District and meet with a member of the merchant s guild you've had dealings with before. He looks at you skeptically, but says he will see what he can do about making the area more livable.\n\nGain 1 prosperity.\n\nOTHERWISE: Every merchant you try to talk to about the issue laughs you out of the room. Why help others when there is no profit in it for them?\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-70-b-a.png',
     },
     optionB: {
       choice: "Regretfully explain that you don't have the power to effect change like this.",
       outcome:
-        'You explain that while you do have some • power in the town, the Sinking Market may be a lost cause. More and more of the district is sinking into the sea every day; as it has been doing for as long as the town has existed. You can t convince merchants to spend money on something that will one day be underwater.\n\nNo effect.',
+        'You explain that while you do have some power in the town, the Sinking Market may be a lost cause. More and more of the district is sinking into the sea every day; as it has been doing for as long as the town has existed. You can\'t convince merchants to spend money on something that will one day be underwater.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-70-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-70-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2754,7 +2754,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 51,
     text:
-      'You move closer, and what you thought wjs a signpost turns out to be a human skull impaled on a spike. there is something sticking out of the skulls mouth. m mwmi w •',
+      'You reach a crossroad and decide to rest for a bit. As you eat some of your rations, something sticking up out of the ground in the distance catches your attention.\n\nYou move closer, and what you thought was a signpost turns out to be a human skull impaled on a spike.\n\nThere is something sticking out of the skulls mouth.',
     optionA: {
       choice: 'Investigate further.',
       outcome:
@@ -2764,7 +2764,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Arm yourself and make a defensive retreat from the area.',
       outcome:
-        "You remember rumors of an assassins guild that places a skull on a pike outside the houses of'their victims before they strike. Fearing the worst, you pull out your weapons and survey the scene as you back away from the pike. Everything looks clear, so you quickly get as far away from the area as possible. Perhaps the skull was not meant for you.\n\nNo effect.",
+        "You remember rumors of an assassins' guild that places a skull on a pike outside the houses of their victims before they strike. Fearing the worst, you pull out your weapons and survey the scene as you back away from the pike. Everything looks clear, so you quickly get as far away from the area as possible. Perhaps the skull was not meant for you.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/road/re-51-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-51-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2964,17 +2964,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 61,
     text:
-      'They are Sun Demons, perhaps the same ones who accosted you earlier That suspicion is confirmed when you get closer and see they are hovering around an armored Valrath woman bound to a tree, torturing her for information. Don \'t you see how important this is!" one of the demons says. "Give us the location of the templet" "Lies and tricks of a demon, * the Sunkeeper responds, " The temple is in no danger except from you.0 — ■ omini mi« mmmmmmi—miii    \t■■ ~\t■■ ■ ■■',
+      'You are heading through a small forest when you hear the sound of a woman screaming off to the west. You silently move closer, catching a glimpse of multiple radiant figures through the tress.\n\nThey are Sun Demons, perhaps the same ones who accosted you earlier. That suspicion is confirmed when you get closer and see they are hovering around an armored Valrath woman bound to a tree, torturing her for information.\n\n"Don\'t you see how important this is!" one of the demons says. "Give us the location of the temple!"\n\n"Lies and tricks of a demon," the Sunkeeper responds. "The temple is in no danger except from you."',
     optionA: {
       choice: 'Leave the scene quietly and return to your own business.',
       outcome:
-        '1 Not wanting to get involved, you simply move • on. Eventually the screams of the Sunkeeper fade away.\n\nAdd Road Event 62 to the deck.',
+        'Not wanting to get involved, you simply move on. Eventually the screams of the Sunkeeper fade away.\n\nAdd Road Event 62 to the deck.',
       imageUrl: '/assets/cards/events/base/road/re-61-b-a.png',
     },
     optionB: {
       choice: 'Attack the demons and free the Sunkeeper.',
       outcome:
-        "You charge out of the trees and attack the Sun Demons. Fueled by righteous indignation and a bit of guilt, you slay them all. The battle leaves you wounded, but the Sunkeeper happily mends your wounds once you free her '7hey seemed to think the Sun Temple is under attack by Night Demons, ” she says• 7 have no reason to believe them, but still\\ would you mind helping me look into it?",
+        "You charge out of the trees and attack the Sun Demons. Fueled by righteous indignation and a bit of guilt, you slay them all. The battle leaves you wounded, but the Sunkeeper happily mends your wounds once you free her.\n\n\"They seemed to think the Sun Temple is under attack by Night Demons,\" she says. \"I have no reason to believe them, but still, would you mind helping me look into it?\"\n\nUnlock \"Sun Temple\" 85 (M-3)",
       imageUrl: '/assets/cards/events/base/road/re-61-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-61-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1336,7 +1336,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Stay and listen to what the Nightshroud has to say.',
       outcome:
-        'The Nightshroud kicks one of the corpses. " This is the Sin-Ra Syndicate, a group of assassins trying to gain a foothold in the region. I\'m trying to stop them, and somehow they found out you and I were friends. They decided to go after you as retribution. Lucky for you. I\'ve located their hideout, so were going to sneak in there and end this whole business once and for all.\n\nUnlock "Syndicate Hideout 89 (C-17).\n\nParty Achievement: "Sin-Ra."',
+        'The Nightshroud kicks one of the corpses. " This is the Sin-Ra Syndicate, a group of assassins trying to gain a foothold in the region. I\'m trying to stop them, and somehow they found out you and I were friends. They decided to go after you as retribution. Lucky for you. I\'ve located their hideout, so were going to sneak in there and end this whole business once and for all.\n\nUnlock "Syndicate Hideout" 89 (C-17).\n\nParty Achievement: "Sin-Ra."',
       imageUrl: '/assets/cards/events/base/city/ce-64-b-a.png',
     },
     optionB: {

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2670,17 +2670,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 47,
     text:
-      '‘EEEEEEEeeeahh! \'* The Vermling drops his weapon and cowers. "No attack! A\\y brothers in the hushes say you had stink of citydwelling outcast on you. I wanted to be sure. * The Vermling waves his hands. It s not had! Just curious. Being stinky city dwelling outcast is fine. Please, dont hurt me!"',
+      'A single Vermling jumps out of the brush at you, surprising you briefly. Within moments, though, you have your weapons out and pressed against his throat.\n\n"EEEEEEEeeeahh!" The Vermling drops his weapon and cowers. "No attack! My brothers in the bushes say you had stink of city-dwelling outcast on you. I wanted to be sure."\n\nThe Vermling waves his hands. "It\' s not bad! Just curious. Being stinky city-dwelling outcast is fine. Please, don\'t hurt me!"',
     optionA: {
       choice: 'Move on, leaving the strange Vermling in peace.',
       outcome:
-        'r R \'Stink very faint " the Vermling continues as * you walk on. "Outcast no longer with your, but I still smell it!" He then jumps back into the brush. Vermlings are very odd creatures.\n\nNo effect.',
+        '"Stink very faint," the Vermling continues as you walk on. "Outcast no longer with you, but I still smell it!"\n\nHe then jumps back into the brush. Vermlings are very odd creatures.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-47-b-a.png',
     },
     optionB: {
       choice: 'Kill the savage little beast.',
       outcome:
-        'You attack the Vermling anyway; despite his protests. It turns out he wasn\'t lying about his "brothers" nearby, though. As you wipe the blood from your blade, ten more of the little furry creatures jump out at youf brandishing small knives. They are not nearly as easy to dispatch.\n\nAll start scenario with {Poison}.\n\nAll start scenario with 2 damage.',
+        'You attack the Vermling anyway; despite his protests. It turns out he wasn\'t lying about his "brothers" nearby, though. As you wipe the blood from your blade, ten more of the little furry creatures jump out at you, brandishing small knives. They are not nearly as easy to dispatch.\n\nAll start scenario with {Poison}.\n\nAll start scenario with 2 damage.',
       imageUrl: '/assets/cards/events/base/road/re-47-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-47-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1543,17 +1543,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 74,
     text:
-      '"Welcome to the Marvelous . _ » ami Magic Techno-Circus!* The Quatryl with a top hat you met on the road greets you as you enter (he circus tent. We always welcome our friends to come and see the wondrous sights! you wander around the pavilion for a while, looking at all signs for .>// manner of improbable creatures. Ultimately you will have to decide on «/ f* what to see first.',
+      '"Welcome to the Marvelous and Magic Techno-Circus!" The Quatryl with a top hat you met on the road greets you as you enter the circus tent. "We always welcome our friends to come and see the wondrous sights!"\n\nYou wander around the pavilion for a while, looking at all signs for manner of improbable creatures. Ultimately you will have to decide on what to see first.',
     optionA: {
-      choice: 'Go watch tlic dancing bean',
+      choice: 'Go watch the dancing bear.',
       outcome:
-        'You enter a smaller tent off the main one and come face-to-face with what is indeed a danc- ing bear. Its handler stands to the side, prod- ding it on occasion, while the bear stands on its hind two legs and shuffles back and forth. It is amusing until the handler prods the bear one too many times and the bear becomes enraged and attacks. You quickly jump into action and subdue the bear, saving the han- dler from getting mauled to death.\n\nGain 1 reputation.',
+        'You enter a smaller tent off the main one and come face-to-face with what is indeed a dancing bear. Its handler stands to the side, prodding it on occasion, while the bear stands on its hind two legs and shuffles back and forth. It is amusing until the handler prods the bear one too many times and the bear becomes enraged and attacks. You quickly jump into action and subdue the bear, saving the handler from getting mauled to death.\n\nGain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-74-b-a.png',
     },
     optionB: {
-      choice: 'Visit the tamed fortune teller.',
+      choice: 'Visit the famed fortune-teller.',
       outcome:
-        'You enter the fortune-teller s tent and the old Orchid woman s expression immediately goes dark; She gestures you to sit at her tableT and when you do, she grabs your arm and looks deep into your eyes. *Your path is dark and cursed\\ There is a shadow around you — a Gloom. You must leave this place. Be rid of it before it con- sumes you* ml.\n\nAll start scenario with {Curse}.\n\nGain 2 experience each.',
+        'You enter the fortune-teller\'s tent and the old Orchid woman\'s expression immediately goes dark. She gestures you to sit at her table, and when you do, she grabs your arm and looks deep into your eyes.\n\n"Your path is dark and cursed. There is a shadow around you — a Gloom. You must leave this place. Be rid of it before it consumes you."\n\nAll start scenario with {Curse}.\n\nGain 2 experience each.',
       imageUrl: '/assets/cards/events/base/city/ce-74-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-74-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1669,17 +1669,17 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 80,
     text:
-      "As you prepare to leave the city on another journey, you are sud- denly surrounded by a large group of guards near the west gate. 'He hear you've been spreading rumors, one of them says. \"Claiming that the guards are causing the Vermling attacks on the city. That‘s some high-grade garbage you 're spewing. “My best friend died in the last Vermling raid!'’ another one veils. You got something smart to say about that? ”",
+      'As you prepare to leave the city on another journey, you are suddenly surrounded by a large group of guards near the west gate.\n\n"We hear you\'ve been spreading rumors," one of them says. "Claiming that the guards are causing the Vermling attacks on the city. That\'s some high-grade garbage you\'re spewing."\n\n"My best friend died in the last Vermling raid!" another one yells. "You got something smart to say about that?"',
     optionA: {
       choice: 'Attempt to calm down the guards and explain the situation.',
       outcome:
-        "if* Jj : You Adopt a serious tone and do your best to communicate dun you fuid nothing to do with what was written in the Town Records. You express remorse for their hardships, and, miraculously, the mob prow's calmer and disperses.\n\nNo effect.\n\nOTHERWISE: You laugh and claim that this is all some big misunderstanding. The guards don't see it that way, but your lack of aggression at least stops them from attacking you. They leave, grumbling threats.\n\nLose 1 reputation.",
+        "{Scoundrel} {Saw} {MusicNote}: You adopt a serious tone and do your best to communicate that you had nothing to do with what was written in the Town Records. You express remorse for their hardships, and, miraculously, the mob grows calmer and disperses.\n\nNo effect.\n\nOTHERWISE: You laugh and claim that this is all some big misunderstanding. The guards don't see it that way, but your lack of aggression at least stops them from attacking you. They leave, grumbling threats.\n\nLose 1 reputation.",
       imageUrl: '/assets/cards/events/base/city/ce-80-b-a.png',
     },
     optionB: {
       choice: 'The guards are not interested in a friendly discourse. Prepare to defend yourself.',
       outcome:
-        'Seeing the situation turning south, you waste no time pulling your weapons and prepare for an attack. The guards are more than happy to oblige. Luckily your foes sustain only some minor injuries in the time it takes for another squad of guards to arrive and break up the scuffle. They let you go on your wayf, but you can see the disdain in all of their eves.\n\nLose 2 reputation.',
+        'Seeing the situation turning south, you waste no time pulling your weapons and prepare for an attack. The guards are more than happy to oblige.\n\nLuckily your foes sustain only some minor injuries in the time it takes for another squad of guards to arrive and break up the scuffle. They let you go on your way, but you can see the disdain in all of their eyes.\n\nLose 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-80-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-80-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1606,15 +1606,15 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 77,
     text:
-      "*Well, well, well. If it isn't the most notorious band o( mercenar- , ♦*» ies in all of Gloomhaven. The guards looking to throw you in the Ghost Fortress yet, or are they on the payroll?' You turn around to see Red Nick, a well known fence, leaning up against the walk You've had certain dealings with him in the past. Fancy seeing you, actually he says. 7ve got a big job, and I figure if anyone wouldn ’t mind digging up graves, it would be you miscreants*\"",
+      '"Well, well, well. If it isn\'t the most notorious band of mercenaries in all of Gloomhaven. The guards looking to throw you in the Ghost Fortress yet, or are they on the payroll?"\n\nYou turn around to see Red Nick, a well-known fence, leaning up against the wall. You\'ve had certain dealings with him in the past.\n\n"Fancy seeing you, actually," he says. "I\'ve got a big job, and I figure if anyone wouldn\'t mind digging up graves, it would be you miscreants."',
     optionA: {
       choice: 'Do the job.',
       outcome:
-        'REPUTATION < -//; "That \'s the money-bring • criminals I know and love! Come take a walk with me, and Til explain how we can all get rich."\n\nOTHERWISE: “Oh, whoops,\' Nick stammers, “From the back you looked like. *. uh, never mind. Forget I said anything. "\n\nNo effect.',
+        'REPUTATION < -14 "That\'s the money-loving criminals I know and love! Come take a walk with me, and I\'ll explain how we can all get rich."\n\nUnlock "Overgrown Graveyard" 75 (G-12).\n\nParty Achievement: "Grave Job."\n\nOTHERWISE: "Oh, whoops," Nick stammers. "From the back you looked like...uh, never mind. Forget I said anything."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-a.png',
     },
     optionB: {
-      choice: 'Claim you’ve changed your ways and graverobbing is a step too far.',
+      choice: 'Claim you\'ve changed your ways and graverobbing is a step too far.',
       outcome:
         '“A downright shame, i say," Nick shakes his head. “I guess I \'ll just have to find a group of mercenaries who actually are interested in make a mountain of money."\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/city/ce-77-b-b.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -2838,17 +2838,17 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 55,
     text:
-      'road. I • ■ m M\t.— One pafA looks clear and easy, but the other path is overgrown with thorns and re will likely get you to where yo  are gotng. The whole situation feels off, though — as if some one or something is watching you. Still a decision must be made. - - -w ■ ■ ■ ^^mmrnm ■ I ■ I .V&+W+4',
+      'You come to a fork in the road. One path looks clear and easy, but the other path is overgrown with thorns and nettles. Either one will likely get you to where you are going.\n\nThe whole situation feels off, though — as if someone or something is watching you.\n\nStill a decision must be made.',
     optionA: {
       choice: 'Take the clear path.',
       outcome:
-        'You walk down the dear path for a few minutes, and, just when you think the whole weird feeling was your imagination, a group of human bandits jumps out at you from the nearby brush. Before they can engage, however, an arrow suddenly spears the chest of the closest bandit, followed very quickly by a second. The bandits have paused to look around in panic when a third arrow flies into another bandit s skull. The bandits scatter and run off. You look around for the shooter, but no trace is found.\n\nNo effect.',
+        'You walk down the clear path for a few minutes, and, just when you think the whole weird feeling was your imagination, a group of human bandits jumps out at you from the nearby brush. Before they can engage, however, an arrow suddenly spears the chest of the closest bandit, followed very quickly by a second. The bandits have paused to look around in panic when a third arrow flies into another bandit\'s skull. The bandits scatter and run off. You look around for the shooter, but no trace is found.\n\nNo effect.',
       imageUrl: '/assets/cards/events/base/road/re-55-b-a.png',
     },
     optionB: {
       choice: 'Take the overgrown path.',
       outcome:
-        'The trek through the overgrown path is unpleasant. You are constantly getting pricked by sharp thorns covered in a strange sap. You think you recognize them f rom a previous foray into harsh, unforgiving foliage. Sure enough, you start feeling sick pretty soon after you emerge from the bushes.\n\nAll start scenario with {Poison}.',
+        'The trek through the overgrown path is unpleasant. You are constantly getting pricked by sharp thorns covered in a strange sap. You think you recognize them from a previous foray into harsh, unforgiving foliage. Sure enough, you start feeling sick pretty soon after you emerge from the bushes.\n\nAll start scenario with {Poison}.',
       imageUrl: '/assets/cards/events/base/road/re-55-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-55-f.png',

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -28,7 +28,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 2,
     text:
-      'As the daylight fades, you find yourselves wandering through a half-crowded market street, browsing wares.\n\n"Hey! Over here!" You turn in the direction of the voice to see a filthy Vermling gesturing from a dark alley. "Yeah, you grim-looking chaps. I have something you might he interested in."\n\nThe Vermling holds out a piece of metal covered in sludge. "Found this in the sewer. Writing on it I don\'t understand, but I know it\'s valuable. You can have it for ten gold!"',
+      'As the daylight fades, you find yourselves wandering through a half-crowded market street, browsing wares.\n\n"Hey! Over here!" You turn in the direction of the voice to see a filthy Vermling gesturing from a dark alley. "Yeah, you grim-looking chaps. I have something you might be interested in."\n\nThe Vermling holds out a piece of metal covered in sludge. "Found this in the sewer. Writing on it I don\'t understand, but I know it\'s valuable. You can have it for ten gold!"',
     optionA: {
       choice: 'Pay for the thing. You never know.',
       outcome:
@@ -375,7 +375,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Agree to help with the rat infestation.',
       outcome:
-        'You smile broadly and ask the woman to lead you to her house. It is a ramshackle dwelling half sunk into the muddy foundation. And inside there are certainly a lot of rats. You kill as many as you can, but in her cellar you find a large hole leading to a section of sewer that recently collapsed, leaving the pests with nowhere else to go. The woman thanks you for at least helping her to he able to sleep tonight and hands you a few coins.\n\nGain 2 gold each.',
+        'You smile broadly and ask the woman to lead you to her house. It is a ramshackle dwelling half sunk into the muddy foundation. And inside there are certainly a lot of rats. You kill as many as you can, but in her cellar you find a large hole leading to a section of sewer that recently collapsed, leaving the pests with nowhere else to go. The woman thanks you for at least helping her to be able to sleep tonight and hands you a few coins.\n\nGain 2 gold each.',
       imageUrl: '/assets/cards/events/base/city/ce-18-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-18-f.png',
@@ -453,7 +453,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Further investigate the exchange between the men.',
       outcome:
-        'You subtly move in the direction of the men, monitoring their actions with your peripheral vision. You recognize the dark robes from the run-ins you have had with cultists in the area, and as you get closer, you become convinced that the vials being traded contain blood. You grab the men and cause a huge amount of commotion as you fight to drag them outside and foil their dealings. You are able to hand them off to the proper authorities, but it may he a while before you are allowed back in the Brown Door. The concert was ruined.\n\nGain 2 reputation.',
+        'You subtly move in the direction of the men, monitoring their actions with your peripheral vision. You recognize the dark robes from the run-ins you have had with cultists in the area, and as you get closer, you become convinced that the vials being traded contain blood. You grab the men and cause a huge amount of commotion as you fight to drag them outside and foil their dealings. You are able to hand them off to the proper authorities, but it may be a while before you are allowed back in the Brown Door. The concert was ruined.\n\nGain 2 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-22-b-a.png',
     },
     optionB: {
@@ -596,7 +596,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 29,
     text:
-      'You get word from a contact that there is trouble brewing down at the East Walls and decide to investigate.\n\nWhat you find is a large contingency of the city\'s Savvas workforce — the best builders you\'ll find anywhere — in open rebellion against the construction managers, demanding better pay for the specialized work they perform. "This city would he a lifeless pile of rocks without us!" one of the Savvas yells. "It\'s time we see some of its prosperity!"\n\nThe manager on the other side of the argument looks like a captured mouse, not sure at all how to get out of the situation.',
+      'You get word from a contact that there is trouble brewing down at the East Walls and decide to investigate.\n\nWhat you find is a large contingency of the city\'s Savvas workforce — the best builders you\'ll find anywhere — in open rebellion against the construction managers, demanding better pay for the specialized work they perform. "This city would be a lifeless pile of rocks without us!" one of the Savvas yells. "It\'s time we see some of its prosperity!"\n\nThe manager on the other side of the argument looks like a captured mouse, not sure at all how to get out of the situation.',
     optionA: {
       choice: 'Talk to the Savvas, appealing to their sense of duty and community.',
       outcome:
@@ -1416,11 +1416,11 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 68,
     text:
-      "You wake in the middle of the night to the sound of rushing water. In the corner ofyour room, you see a flood gushing out of the head of the Summoner's staff which you had previously picked up in your travels. You jump out of bed and splash through a growing puddle of water to investigate the staff, but you can't make any sense of it. ft seems to he materializing the water out of thin air, possibly channeling it from another plane of existence. You scratch your head, unsure of what to do next.",
+      "You wake in the middle of the night to the sound of rushing water. In the corner ofyour room, you see a flood gushing out of the head of the Summoner's staff which you had previously picked up in your travels. You jump out of bed and splash through a growing puddle of water to investigate the staff, but you can't make any sense of it. ft seems to be materializing the water out of thin air, possibly channeling it from another plane of existence. You scratch your head, unsure of what to do next.",
     optionA: {
       choice: 'Kind some way to get the water to stop gushing.',
       outcome:
-        '; You take a moment to attune yourself to the staff which you feel now has a direct link another plane. The water stops and you are left with an openga Unlock Plane of Water "(88)(D-l6}. Party Achievement: “Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not he happy.\n\nLose 15 collective gold. Unlock "Plane of Water (8&(D-l6). Party Achievement: \'Water Staff."',
+        '; You take a moment to attune yourself to the staff which you feel now has a direct link another plane. The water stops and you are left with an openga Unlock Plane of Water "(88)(D-l6}. Party Achievement: “Water Staff."\n\nOTHERWISE: You figure out how to work the staff but not before your entire room is flooded. The innkeeper will not be happy.\n\nLose 15 collective gold. Unlock "Plane of Water (8&(D-l6). Party Achievement: \'Water Staff."',
       imageUrl: '/assets/cards/events/base/city/ce-68-b-a.png',
     },
     optionB: {
@@ -1458,7 +1458,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 70,
     text:
-      'You are wandering the Sink- ing Market looking for possible work when you are approached by a dirty-looking bov with a scar on his check. You greet him warmly. He has given you leads on a number of mercenary jobs and you re- cently helped him avoid a jail ceil. "I need some help, and I really don\'t know who else to turn to, " he begins. \'All of us here in (he Sinking Market are in a had way; Our houses are collapsing, our water is foul\\ and we den t even have enough money for food[ "We are dying here. and the city is doing nothing to help us. You have friends in high places, right? Please, there \'s gotta he someone you can talk to.',
+      'You are wandering the Sink- ing Market looking for possible work when you are approached by a dirty-looking bov with a scar on his check. You greet him warmly. He has given you leads on a number of mercenary jobs and you re- cently helped him avoid a jail ceil. "I need some help, and I really don\'t know who else to turn to, " he begins. \'All of us here in (he Sinking Market are in a had way; Our houses are collapsing, our water is foul\\ and we den t even have enough money for food[ "We are dying here. and the city is doing nothing to help us. You have friends in high places, right? Please, there \'s gotta be someone you can talk to.',
     optionA: {
       choice: 'Talk to some merchants about revital- izing the area.',
       outcome:
@@ -1505,13 +1505,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Follow the smelly old bandit.',
       outcome:
-        'Your curiosity gets the better of your judg- • ment. You need to know the purpose of the device you found, so you follow Fish into«) derelict shock where he pulls out a mop of the area ond lo vs it on o table. Fish directs you to pull out your rod ond both you ond he hold your respective rods over the toble. 4 specific location on the mop glows brightly ond Fish loughs. ‘See? I toldya. didn \'t I? Meet me there with your rod and we ll get rich!" Unlock Lost Temple (79)(K-I2). Party Achievement: "Fish\'s Aid.”',
+        'Your curiosity gets the better of your judg- • ment. You need to know the purpose of the device you found, so you follow Fish into«) derelict shock where he pulls out a map of the area ond lays it on o table. Fish directs you to pull out your rod ond both you and he hold your respective rods over the toble. 4 specific location on the mop glows brightly ond Fish loughs. ‘See? I toldya. didn \'t I? Meet me there with your rod and we ll get rich!" Unlock Lost Temple (79)(K-I2). Party Achievement: "Fish\'s Aid.”',
       imageUrl: '/assets/cards/events/base/city/ce-72-b-a.png',
     },
     optionB: {
       choice: 'Refuse to go with the man. This whole situation seems fishy.',
       outcome:
-        "This suspicious old man must have seen you in here before with the rod and fashioned some elaborate con to swindle you out of something. You won i be so easily fooled. There 's no he knows what the rod does when no one else in town does. Vbi/ push him away and go back to your drink.\n\nNo effect.",
+        "This suspicious old man must have seen you in here before with the rod and fashioned some elaborate con to swindle you out of something. You won i be so easily fooled. There's no he knows what the rod does when no one else in town does. Vbi/ push him away and go back to your drink.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-72-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/city/ce-72-f.png',
@@ -1526,7 +1526,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Seek help from the University.',
       outcome:
-        "“Yes, verv interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold. Unlock Crystalline Cave\" 84 (CM2:. Partv Achievement: \"Tremors.'",
+        "“Yes, very interesting, ' a bookish Quatryl says as he rolls the crystal over in his hand. “It seems os if this crystal is attuned to a specific location, and once removed, it begins vibrating until mountains and houses start falling down. I'd say you need to return it to its proper home. \\ \\ ith the proper tools — which I'll need help paying for — I should be able to triangulate that location for you.\n\nLose 5 collective gold. Unlock Crystalline Cave\" 84 (CM2:. Partv Achievement: \"Tremors.'",
       imageUrl: '/assets/cards/events/base/city/ce-73-b-a.png',
     },
     optionB: {
@@ -1606,7 +1606,7 @@ export const events: EventEntity[] = [
     type: EventType.City,
     number: 77,
     text:
-      "*Well, well, well. If it isn't the most notorious band o( mercenar- , ♦*» ies in all of Gloomhaven. The guards looking to throw you in the Ghost Fortress yet, or are they on the payroll?' You turn around to see Red Nick, a well known fence, leaning up against the walk You've had certain dealings with him in the past. Fancy seeing you, actually he says. 7ve got a big job, and I figure if anyone wouldn ’t mind digging up graves, it would he you miscreants*\"",
+      "*Well, well, well. If it isn't the most notorious band o( mercenar- , ♦*» ies in all of Gloomhaven. The guards looking to throw you in the Ghost Fortress yet, or are they on the payroll?' You turn around to see Red Nick, a well known fence, leaning up against the walk You've had certain dealings with him in the past. Fancy seeing you, actually he says. 7ve got a big job, and I figure if anyone wouldn ’t mind digging up graves, it would be you miscreants*\"",
     optionA: {
       choice: 'Do the job.',
       outcome:
@@ -2659,7 +2659,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Forget about the rocks and continue on your journey.',
       outcome:
-        "You shake your head and move past the ridge. You have more important things to do than climb rocks. Still, you fed the pull of the site, even after it fades from view. You get the feeling that this won't he the last time you see it.\n\nNo effect.",
+        "You shake your head and move past the ridge. You have more important things to do than climb rocks. Still, you fed the pull of the site, even after it fades from view. You get the feeling that this won't be the last time you see it.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/road/re-46-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-46-f.png',
@@ -2680,7 +2680,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Kill the savage little beast.',
       outcome:
-        'You attack the Vermling anyway; despite his protests. It t urns out he wasn *t lying about his "brothers" nearby, though. As you wipe the blood from your blade, ten more of the little furry creatures jump out at youf brandishing small knives. They are not nearly as easy to dispatch.\n\nAll start scenario with {Poison}.\n\nAll start scenario with 2 damage.',
+        'You attack the Vermling anyway; despite his protests. It turns out he wasn\'t lying about his "brothers" nearby, though. As you wipe the blood from your blade, ten more of the little furry creatures jump out at youf brandishing small knives. They are not nearly as easy to dispatch.\n\nAll start scenario with {Poison}.\n\nAll start scenario with 2 damage.',
       imageUrl: '/assets/cards/events/base/road/re-47-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-47-f.png',
@@ -2758,13 +2758,13 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Investigate further.',
       outcome:
-        "You get closer to the pike. The skull looks pretty fresh There are still bits of decayed flesh attached to the bonef and flies buzz around it* You can see there is a small paper card stuck in its mouth so you caref ully reach in and pull it out. I he card is black and depicts a skull with blades running through it. Come to think of it you remember rumors of an assassins' guild that has been known to use the same imagery You get out of the area as quickly as you can.\n\nGain 1 collective “Black Card” (Item 129).",
+        "You get closer to the pike. The skull looks pretty fresh. There are still bits of decayed flesh attached to the bone, and flies buzz around it. You can see there is a small paper card stuck in its mouth so you carefully reach in and pull it out. The card is black and depicts a skull with blades running through it. Come to think of it you remember rumors of an assassins' guild that has been known to use the same imagery You get out of the area as quickly as you can.\n\nGain 1 collective “Black Card” (Item 129).",
       imageUrl: '/assets/cards/events/base/road/re-51-b-a.png',
     },
     optionB: {
       choice: 'Arm yourself and make a defensive retreat from the area.',
       outcome:
-        "You remember rumors of an assassins guild that places a skull on a pike outside the houses of'their victims before they strike. Fearing the worst, you pull out your weapons and survey t he scene as you back away from the pike. Everything looks clear, so you quickly get as far away from the area as possible. Perhaps the skull was not meant for you.\n\nNo effect.",
+        "You remember rumors of an assassins guild that places a skull on a pike outside the houses of'their victims before they strike. Fearing the worst, you pull out your weapons and survey the scene as you back away from the pike. Everything looks clear, so you quickly get as far away from the area as possible. Perhaps the skull was not meant for you.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/road/re-51-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-51-f.png',
@@ -2827,7 +2827,7 @@ export const events: EventEntity[] = [
     optionB: {
       choice: 'Give detailed directions about the way out and hope that is sufficient.',
       outcome:
-        "W V\tf\tL/tar\triru mejig/ve precise directions on the easiest way out of the forest and back to the main road. The Soothsinger seems impressed and waves good-bye as she heads off.\n\nGain 1 reputation.\n\n : You gauge your bearings and\n\nOTHERWISE: You hem and haw and then give some vague directions back to the road' t he Soothsinger looks at you skeptically and heads off.\n\nAdd City Event 69 to the deck.",
+        "W V\tf\tL/tar\triru mejig/ve precise directions on the easiest way out of the forest and back to the main road. The Soothsinger seems impressed and waves good-bye as she heads off.\n\nGain 1 reputation.\n\n : You gauge your bearings and\n\nOTHERWISE: You hem and haw and then give some vague directions back to the road' the Soothsinger looks at you skeptically and heads off.\n\nAdd City Event 69 to the deck.",
       imageUrl: '/assets/cards/events/base/road/re-54-b-b.png',
     },
     imageUrl: '/assets/cards/events/base/road/re-54-f.png',
@@ -2922,7 +2922,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 59,
     text:
-      'The\tair is especially humid and muggy as you walk towards your destination, but even that couldn’t explain the sight that greets you on the road. Directly in Iront of you, completely blocking the only available path, is a massive swarm of insects. There must he millions of them. >bt/ take a hesitant step forward and the bugs do not react. They are not concerned by your presence at all. — w    \t■&» ■». m« mwi',
+      'The\tair is especially humid and muggy as you walk towards your destination, but even that couldn’t explain the sight that greets you on the road. Directly in Iront of you, completely blocking the only available path, is a massive swarm of insects. There must be millions of them. >bt/ take a hesitant step forward and the bugs do not react. They are not concerned by your presence at all. — w    \t■&» ■». m« mwi',
     optionA: {
       choice: 'Cover yourself as best you can and try to walk through the swarm.',
       outcome:
@@ -3027,7 +3027,7 @@ export const events: EventEntity[] = [
     type: EventType.Road,
     number: 64,
     text:
-      'You move closer, and what you thought was a signpost turns out to he a human skull impaled on a spike. There is something sticking out of the skulls mouth. ^  — - ■ i ii HWW ■ *»-»■ ■* * — —■\t— ■ i ■<————',
+      'You move closer, and what you thought was a signpost turns out to be a human skull impaled on a spike. There is something sticking out of the skulls mouth. ^  — - ■ i ii HWW ■ *»-»■ ■* * — —■\t— ■ i ■<————',
     optionA: {
       choice: 'Investigate further.',
       outcome:

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -1424,7 +1424,7 @@ export const events: EventEntity[] = [
       imageUrl: '/assets/cards/events/base/city/ce-68-b-a.png',
     },
     optionB: {
-      choice: 'Gel the stall out ot your room and throw it into the bay. a l I',
+      choice: 'Gel the stall out of your room and throw it into the bay. a l I',
       outcome:
         "You race out of the inn, trying to minimize the damage caused by the never-ending stream of water. Not knowing what else to do, you head toward the river. Standing on the banks, you shrug and toss the staff into the current. You g uess you 'll never know how the staff ended up where it did or why it suddenly turned into a faucet.\n\nNo effect.",
       imageUrl: '/assets/cards/events/base/city/ce-68-b-b.png',
@@ -1441,7 +1441,7 @@ export const events: EventEntity[] = [
     optionA: {
       choice: 'Embrace the joke and go with it.',
       outcome:
-        'You nuke your way to the front ot the crowd and join in the tun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus, ft s a lit tie embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
+        'You nuke your way to the front of the crowd and join in the fun. When the Soothsinger notices you in the crowd, she brings you up on stage for the chorus, ft s a lit tie embarrassing, but people are enjoying your positive attitude about it.\n\nGain 1 reputation.',
       imageUrl: '/assets/cards/events/base/city/ce-69-b-a.png',
     },
     optionB: {


### PR DESCRIPTION
* replaced smart quotes with double quotes and single quotes
* added new lines for paragraphs

BROKEN
* road event 36 and road event 46 contain runes, I encoded those with {RuneX} (where X is a letter or digit) but the actual SVG are not supplied within this PR and the encoding does spoil the "encryption" and secret

MISSING:
* resolves for events such as {RemoveFromGame} and {ReturnToGame} as I didn't know where to put it in the data