### PR TITLE
Fix issue with Next Event / Prev Event

### DIFF
--- a/src/client/app/+events/+event/event-page.component.html
+++ b/src/client/app/+events/+event/event-page.component.html
@@ -3,7 +3,7 @@
 <div class="content">
   <div class="nav">
     <div class="first-cell">
-      <a *ngIf="event.number > 1" [routerLink]="[`/events/${event.type}`, event.number - 1]">
+      <a *ngIf="event.number > 1" [routerLink]="['/events', event.type, event.number - 1]">
         <fa-icon [icon]="prevIcon"></fa-icon>
         View Previous Event
       </a>
@@ -15,7 +15,7 @@
       </a>
     </div>
     <div class="last-cell">
-      <a *ngIf="event.number < 150" [routerLink]="[`/events/${event.type}`, event.number + 1]">
+      <a *ngIf="event.number < 150" [routerLink]="['/events', event.type, event.number + 1]">
         <fa-icon [icon]="nextIcon"></fa-icon>
         View Next Event
       </a>

--- a/src/client/app/+events/+event/event-page.component.html
+++ b/src/client/app/+events/+event/event-page.component.html
@@ -3,7 +3,7 @@
 <div class="content">
   <div class="nav">
     <div class="first-cell">
-      <a *ngIf="event.number > 1" [routerLink]="['/events', event.number - 1]">
+      <a *ngIf="event.number > 1" [routerLink]="[`/events/${event.type}`, event.number - 1]">
         <fa-icon [icon]="prevIcon"></fa-icon>
         View Previous Event
       </a>
@@ -15,7 +15,7 @@
       </a>
     </div>
     <div class="last-cell">
-      <a *ngIf="event.number < 150" [routerLink]="['/events', event.number + 1]">
+      <a *ngIf="event.number < 150" [routerLink]="[`/events/${event.type}`, event.number + 1]">
         <fa-icon [icon]="nextIcon"></fa-icon>
         View Next Event
       </a>


### PR DESCRIPTION
The issue:

Starting on a page like https://gloomhavendb.com/events/city/1 and hitting 'View Next Event' brings you to https://gloomhavendb.com/events/2 , which is an invalid link.  

The fix:

I've added the event type to the url.

Please note, I haven't actually tested this locally by running the app.